### PR TITLE
Feat[#THKV-13]: ControlTab 공통 컴포넌트 구현 

### DIFF
--- a/src/app/seunghyun/page.tsx
+++ b/src/app/seunghyun/page.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useState } from 'react';
+import ControlTab from '@/components/ControlTab';
 import { Input } from '@/components/Input/Input';
 import {
   BodyPrimary,
@@ -8,6 +10,8 @@ import {
 
 const page = () => {
   const value = '추후 useInput를 통해 받아올 value';
+  const tabList = ['최신순', '오래된순'];
+  const [selectedTab, setSelectedTab] = useState('최신순'); // eslint-disable-line react-hooks/rules-of-hooks
   return (
     <div className='flex flex-col gap-3'>
       <BodyPrimary>바디 Primary색상임다</BodyPrimary>
@@ -32,6 +36,11 @@ const page = () => {
         value={value}
       />
       <Input disabled />
+      <ControlTab
+        controlTabItems={tabList}
+        selectedTab={selectedTab}
+        setSelectedTab={setSelectedTab}
+      />
     </div>
   );
 };

--- a/src/components/ControlTab/index.tsx
+++ b/src/components/ControlTab/index.tsx
@@ -1,0 +1,33 @@
+import { Dispatch, SetStateAction } from 'react';
+import { cn } from '@/utils/core';
+
+type Props<T> = {
+  controlTabItems: readonly T[];
+  selectedTab: T;
+  setSelectedTab: Dispatch<SetStateAction<T>>;
+};
+
+const ControlTab = <T extends string>({
+  controlTabItems,
+  selectedTab,
+  setSelectedTab,
+}: Props<T>) => {
+  return (
+    <div className='flex gap-2'>
+      {controlTabItems.map((tab) => (
+        <button
+          key={tab}
+          className={cn(
+            'text-sm text-gray-400',
+            tab === selectedTab && 'text-gray-600 font-semibold',
+          )}
+          onClick={() => setSelectedTab(tab)}
+        >
+          {tab}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+export default ControlTab;


### PR DESCRIPTION

## 관련 문서

- issue: #
- close #

## 유형

- [ ] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

정렬에 필요한 ControlTab 공통 컴포넌트 구현

-

### 설명 (선택)

prop으로 탭으로 보여질 리스트, useState를 통한 상태와 상태변경함수를 내려주고 ControlTab에서 선택된 탭을 변경해주는 방법으로 작성


## 스크린샷
<img width="59" alt="스크린샷 2024-09-01 오전 10 07 24" src="https://github.com/user-attachments/assets/f3d16e73-4805-4bda-a5d8-46d6c3072e4c">


## 리뷰 요구사항

page.tsx 14line의 주석은 page에 hook이 쓰여서 생기는 eslint에러를 잠시 테스트동안만 잡기 위해서 사용했습니다.
실제 컴포넌트에서 ControlTab 컴포넌트를 사용하실때는 사용하시지않아도되니 참고바랍니다.

해당 컴포넌트의 button태그는 text-color만 변경되는 컴포넌트이기 때문에 기본button태그를 사용하였습니다

-
