### PR TITLE
Feat[#THKV-14]: Radio 공통 컴포넌트 구현

### DIFF
--- a/src/app/seunghyun/page.tsx
+++ b/src/app/seunghyun/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 import { Input } from '@/components/Input/Input';
+import Radio from '@/components/Radio';
 import {
   BodyPrimary,
   HeadPrimary,
@@ -32,6 +33,16 @@ const page = () => {
         value={value}
       />
       <Input disabled />
+      <div className='flex gap-4'>
+        <div className='flex items-center gap-1'>
+          <Radio color='primary' name='test' />
+          <Label>test1</Label>
+        </div>
+        <div className='flex items-center gap-1'>
+          <Radio color='secondary' name='test' />
+          <Label>test2</Label>
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/Radio/Radio.variant.tsx
+++ b/src/components/Radio/Radio.variant.tsx
@@ -1,0 +1,16 @@
+import { cva } from 'class-variance-authority';
+
+export const radioVariant = cva(
+  'size-4 cursor-pointer appearance-none rounded-full border-[1.5px] border-input bg-transparent outline-none checked:border-[3px] checked:border-solid checked:border-transparent checked:bg-clip-padding disabled:cursor-default',
+  {
+    variants: {
+      color: {
+        primary: 'checked:bg-buttonPrimaryActive',
+        secondary: 'checked:bg-buttonSecondaryActive',
+      },
+    },
+    defaultVariants: {
+      color: 'primary',
+    },
+  },
+);

--- a/src/components/Radio/index.tsx
+++ b/src/components/Radio/index.tsx
@@ -1,0 +1,20 @@
+import { VariantProps } from 'class-variance-authority';
+import { cn } from '@/utils/core';
+import { radioVariant } from './Radio.variant';
+
+type Props = React.InputHTMLAttributes<HTMLInputElement> &
+  VariantProps<typeof radioVariant>;
+
+const Radio = ({ checked, color, className, disabled, ...props }: Props) => {
+  return (
+    <input
+      type='radio'
+      checked={checked}
+      disabled={disabled}
+      className={cn(radioVariant({ color }), className)}
+      {...props}
+    />
+  );
+};
+
+export default Radio;


### PR DESCRIPTION
## 관련 문서

- issue: #THKV-14
- close #

## 유형

- [ ] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

Radio 공통 컴포넌트 UI 구현


### 설명 (선택)

Radio checked 스타일을 variant로 두고, 나머지 사용방법은 초기의 input radio타입 사용법과 동일하게 가져갔습니다.

## 스크린샷
<img width="72" alt="스크린샷 2024-09-01 오전 10 31 39" src="https://github.com/user-attachments/assets/79768969-0685-4e38-be77-71db41b68de5">


## 리뷰 요구사항

