### PR TITLE
Feat[#THKV-17]: Modal 컴포넌트 구현

### DIFF
--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef } from 'react';
 import Icon from '../Icon';
-import { ModalHeadWhite } from '../Typography/Typography';
+import { HeadPrimary } from '../Typography/Typography';
 
 export type Props = {
   isOpen: boolean;
@@ -31,7 +31,7 @@ export const Modal = ({
         ref={modalRef}
       >
         <div className='flex items-center justify-between'>
-          <ModalHeadWhite>{title}</ModalHeadWhite>
+          <HeadPrimary>{title}</HeadPrimary>
           {showCloseButton && (
             <div onClick={onClose} className='cursor-pointer'>
               <Icon name='xmark' width={15} height={15} />

--- a/src/components/Modal/index.tsx
+++ b/src/components/Modal/index.tsx
@@ -1,0 +1,45 @@
+import { ComponentPropsWithoutRef } from 'react';
+import Icon from '../Icon';
+import { ModalHeadWhite } from '../Typography/Typography';
+
+export type Props = {
+  isOpen: boolean;
+  showCloseButton?: boolean;
+  onClose: () => void;
+  modalRef: React.Ref<HTMLDivElement>;
+  title: string;
+  children: React.ReactNode;
+} & ComponentPropsWithoutRef<'div'>;
+
+export const Modal = ({
+  title,
+  isOpen,
+  onClose,
+  modalRef,
+  showCloseButton = true,
+  children,
+  ...modalProps
+}: Props) => {
+  if (!isOpen) return null;
+  return (
+    <div
+      className='absolute left-0 top-0 z-50 flex h-full w-full items-center justify-center bg-black bg-opacity-20'
+      {...modalProps}
+    >
+      <div
+        className='w-[90%] max-w-[400px] rounded-xl bg-primary p-5'
+        ref={modalRef}
+      >
+        <div className='flex items-center justify-between'>
+          <ModalHeadWhite>{title}</ModalHeadWhite>
+          {showCloseButton && (
+            <div onClick={onClose} className='cursor-pointer'>
+              <Icon name='xmark' width={15} height={15} />
+            </div>
+          )}
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Modal/useModal.ts
+++ b/src/components/Modal/useModal.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export const useModal = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  const openModal = () => {
+    setIsOpen(true);
+  };
+
+  const closeModal = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const handleOutsideClick = useCallback(
+    (event: MouseEvent) => {
+      if (
+        modalRef.current &&
+        !modalRef.current.contains(event.target as Node) &&
+        isOpen
+      ) {
+        closeModal();
+      }
+    },
+    [closeModal, isOpen],
+  );
+
+  useEffect(() => {
+    document.addEventListener('mousedown', handleOutsideClick);
+
+    return () => {
+      document.removeEventListener('mousedown', handleOutsideClick);
+    };
+  }, [isOpen, closeModal, handleOutsideClick]);
+  return { isOpen, modalRef, openModal, closeModal };
+};

--- a/src/components/TableBody/index.tsx
+++ b/src/components/TableBody/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+type Data = {
+  id: number;
+  title: string;
+  description: string;
+  createdAt: string;
+};
+
+export type DataList = Data[];
+interface Props {
+  data: DataList;
+}
+const TableBody = ({ data }: Props) => {
+  return (
+    <tbody>
+      {data.map((item, idx) => (
+        <tr
+          key={idx}
+          className='flex h-14 w-full items-center justify-between border-b-[1px] border-thead bg-tableHeader px-3 text-xs'
+        >
+          {Object.entries(item).map(([key, value]) => {
+            return (
+              <th key={key} className='font-normal'>
+                {value}
+              </th>
+            );
+          })}
+        </tr>
+      ))}
+    </tbody>
+  );
+};
+
+export default TableBody;

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -26,11 +26,6 @@ export const HeadPrimary = customTypography('h1', {
   type: 'heading1',
   weight: 'bold',
 });
-export const ModalHeadWhite = customTypography('h1', {
-  type: 'heading1',
-  weight: 'bold',
-  color: 'white',
-});
 export const BodyPrimary = customTypography('p', {
   type: 'body1',
 });

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -26,6 +26,11 @@ export const HeadPrimary = customTypography('h1', {
   type: 'heading1',
   weight: 'bold',
 });
+export const ModalHeadWhite = customTypography('h1', {
+  type: 'heading1',
+  weight: 'bold',
+  color: 'white',
+});
 export const BodyPrimary = customTypography('p', {
   type: 'body1',
 });


### PR DESCRIPTION

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

Modal 컴포넌트, useModal 커스텀 훅 작성

-

### 설명 (선택)

Modal children으로 내부요소를 받아서 모달 안에서 띄워준다.
useModal 훅을 통해 열고닫히는 함수, ref부착, isOpen상태를 부모컴포넌트에서 받아와 Modal컴포넌트에 prop로 보내줌.

## 스크린샷
<img width="805" alt="스크린샷 2024-09-01 오후 5 11 52" src="https://github.com/user-attachments/assets/84b1faa9-aed3-4685-b995-5813b00e7be9">


## 리뷰 요구사항

form layout이나, flexBox같은 컴포넌트도 만들어놓으면 Modal에서나, 
다른 컴포넌트들에서 유용하게 사용할 수 있을 것 같은데 어떠신가요!?

-
