### PR TITLE
Feat[#THKV-16]: Pagination 컴포넌트 구현

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,0 +1,75 @@
+import Link from 'next/link';
+import React from 'react';
+import Icon from '../Icon';
+
+interface Props {
+  totalPosts: number;
+  currentPage: number;
+  pageSize: number;
+  category: string;
+}
+
+const Pagination = ({ totalPosts, currentPage, pageSize, category }: Props) => {
+  const totalPages = Math.ceil(totalPosts / pageSize);
+
+  const floorFive = 5 * Math.floor(currentPage / 5);
+  const ceilFive = 5 * Math.ceil(currentPage / 5);
+
+  const prevPage = floorFive - 4;
+  const nextPage = ceilFive + 1;
+
+  const startPage = ceilFive - 4;
+
+  const generatePageLinks = (currentPage: number) => {
+    const links = [];
+
+    const lastPage = totalPages >= ceilFive ? startPage + 4 : totalPages;
+    for (let i = startPage; i <= lastPage; i++) {
+      links.push(
+        <Link
+          key={i}
+          href={{
+            pathname: `${category}`,
+            query: { page: `${i}` },
+          }}
+          className={`mx-1 w-10 rounded-full p-2 text-center hover:bg-navAction hover:text-white ${
+            i === currentPage ? 'bg-navActionActive text-white' : ''
+          }`}
+        >
+          {i}
+        </Link>,
+      );
+    }
+    return links;
+  };
+
+  return (
+    <div className='flex items-center justify-center p-2'>
+      {currentPage <= 5 ? null : (
+        <Link
+          className='m-2 flex justify-center rounded-full p-2 text-center hover:bg-navAction'
+          href={{
+            pathname: `/${category}`,
+            query: { page: `${prevPage}` },
+          }}
+        >
+          <Icon name='arrowPrev' width={15} height={15} />
+        </Link>
+      )}
+      {generatePageLinks(currentPage)}
+      {totalPages < ceilFive ? null : (
+        <Link
+          className='m-2 flex justify-center rounded-full p-2 text-center hover:bg-navAction'
+          href={{
+            pathname: `/${category}`,
+            query: { page: `${nextPage}` },
+          }}
+        >
+          <Icon name='arrowNext' width={15} height={15} />
+        </Link>
+      )}
+    </div>
+  );
+};
+
+export default Pagination;

--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import React from 'react';
 import Icon from '../Icon';
+import { CAL_PAGE_NUM } from '@/constants/_pagination';
 
 interface Props {
   totalPosts: number;
@@ -12,18 +12,19 @@ interface Props {
 const Pagination = ({ totalPosts, currentPage, pageSize, category }: Props) => {
   const totalPages = Math.ceil(totalPosts / pageSize);
 
-  const floorFive = 5 * Math.floor(currentPage / 5);
-  const ceilFive = 5 * Math.ceil(currentPage / 5);
+  const floorFive = pageSize * Math.floor(currentPage / pageSize);
+  const ceilFive = pageSize * Math.ceil(currentPage / pageSize);
 
-  const prevPage = floorFive - 4;
-  const nextPage = ceilFive + 1;
+  const prevPage = floorFive - CAL_PAGE_NUM.FIRST_PAGE;
+  const nextPage = ceilFive + CAL_PAGE_NUM.LAST_PAGE;
 
-  const startPage = ceilFive - 4;
+  const startPage = ceilFive - CAL_PAGE_NUM.FIRST_PAGE;
 
   const generatePageLinks = (currentPage: number) => {
     const links = [];
 
-    const lastPage = totalPages >= ceilFive ? startPage + 4 : totalPages;
+    const lastPage =
+      totalPages >= ceilFive ? startPage + CAL_PAGE_NUM.FIRST_PAGE : totalPages;
     for (let i = startPage; i <= lastPage; i++) {
       links.push(
         <Link
@@ -45,7 +46,7 @@ const Pagination = ({ totalPosts, currentPage, pageSize, category }: Props) => {
 
   return (
     <div className='flex items-center justify-center p-2'>
-      {currentPage <= 5 ? null : (
+      {!(currentPage <= pageSize) && (
         <Link
           className='m-2 flex justify-center rounded-full p-2 text-center hover:bg-navAction'
           href={{
@@ -57,7 +58,7 @@ const Pagination = ({ totalPosts, currentPage, pageSize, category }: Props) => {
         </Link>
       )}
       {generatePageLinks(currentPage)}
-      {totalPages < ceilFive ? null : (
+      {!(totalPages < ceilFive) && (
         <Link
           className='m-2 flex justify-center rounded-full p-2 text-center hover:bg-navAction'
           href={{

--- a/src/components/icons/ArrowNext.tsx
+++ b/src/components/icons/ArrowNext.tsx
@@ -1,0 +1,26 @@
+import React, { SVGProps } from 'react';
+
+const ArrowNext = ({
+  width = 20,
+  height = 20,
+  color = '#000',
+  ...props
+}: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      {...props}
+    >
+      <path
+        d='M9.71069 18.2929C10.1012 18.6834 10.7344 18.6834 11.1249 18.2929L16.0123 13.4006C16.7927 12.6195 16.7924 11.3537 16.0117 10.5729L11.1213 5.68254C10.7308 5.29202 10.0976 5.29202 9.70708 5.68254C9.31655 6.07307 9.31655 6.70623 9.70708 7.09676L13.8927 11.2824C14.2833 11.6729 14.2833 12.3061 13.8927 12.6966L9.71069 16.8787C9.32016 17.2692 9.32016 17.9023 9.71069 18.2929Z'
+        fill={color}
+      />
+    </svg>
+  );
+};
+
+export default ArrowNext;

--- a/src/components/icons/ArrowNext.tsx
+++ b/src/components/icons/ArrowNext.tsx
@@ -1,4 +1,4 @@
-import React, { SVGProps } from 'react';
+import { SVGProps } from 'react';
 
 const ArrowNext = ({
   width = 20,

--- a/src/components/icons/ArrowPrev.tsx
+++ b/src/components/icons/ArrowPrev.tsx
@@ -1,4 +1,4 @@
-import React, { SVGProps } from 'react';
+import { SVGProps } from 'react';
 
 const ArrowPrev = ({
   width = 20,

--- a/src/components/icons/ArrowPrev.tsx
+++ b/src/components/icons/ArrowPrev.tsx
@@ -1,0 +1,26 @@
+import React, { SVGProps } from 'react';
+
+const ArrowPrev = ({
+  width = 20,
+  height = 20,
+  color = '#000',
+  ...props
+}: SVGProps<SVGSVGElement>) => {
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+      {...props}
+    >
+      <path
+        d='M14.2893 5.70708C13.8988 5.31655 13.2657 5.31655 12.8751 5.70708L7.98768 10.5993C7.20729 11.3805 7.2076 12.6463 7.98837 13.427L12.8787 18.3174C13.2693 18.7079 13.9024 18.7079 14.293 18.3174C14.6835 17.9269 14.6835 17.2937 14.293 16.9032L10.1073 12.7175C9.71678 12.327 9.71678 11.6939 10.1073 11.3033L14.2893 7.12129C14.6799 6.73077 14.6799 6.0976 14.2893 5.70708Z'
+        fill={color}
+      />
+    </svg>
+  );
+};
+
+export default ArrowPrev;

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,4 +1,6 @@
 import ArrowDown from './ArrowDown';
+import ArrowNext from './ArrowNext';
+import ArrowPrev from './ArrowPrev';
 import Arrowup from './ArrowUp';
 import Edit from './Edit';
 import Search from './Search';
@@ -10,6 +12,8 @@ export const iconMap = {
   xmark: Xmark,
   arrowUp: Arrowup,
   arrowDown: ArrowDown,
+  arrowPrev: ArrowPrev,
+  arrowNext: ArrowNext,
 };
 
 export const COLORS = {

--- a/src/constants/_pagination.ts
+++ b/src/constants/_pagination.ts
@@ -1,0 +1,4 @@
+export const CAL_PAGE_NUM = {
+  FIRST_PAGE: 4,
+  LAST_PAGE: 1,
+};


### PR DESCRIPTION

## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

Pagination 컴포넌트 구현
-

### 설명 (선택)

Pagination 컴포넌트에 Prop으로 pathname, 컨텐츠총 크기, 한페이지의 크기를 prop으로 보내주어
그 수에 맞게 페이지네이션 동작합니다.

## 스크린샷
<img width="317" alt="스크린샷 2024-09-01 오후 7 11 50" src="https://github.com/user-attachments/assets/ae9666e3-4d48-4ddf-a52f-ec09d75b70ad">


## 리뷰 요구사항


-
