### PR TITLE
Fix[#THKV-26]: Pagination block단위로 페이지 나눠지게 수정

### DIFF
--- a/src/app/seunghyun/page.tsx
+++ b/src/app/seunghyun/page.tsx
@@ -22,6 +22,10 @@ const page = () => {
   const tabList = ['최신순', '오래된순'];
   const [selectedTab, setSelectedTab] = useState('최신순'); // eslint-disable-line react-hooks/rules-of-hooks
   const { isOpen, modalRef, openModal, closeModal } = useModal(); // eslint-disable-line react-hooks/rules-of-hooks
+  const limit = 4;
+  const [page, setPage] = useState(1); // eslint-disable-line react-hooks/rules-of-hooks
+  // const [selection, setSelection] = useState(new Set()); // eslint-disable-line react-hooks/rules-of-hooks
+
   return (
     <div className='flex flex-col gap-3'>
       <BodyPrimary>바디 Primary색상임다</BodyPrimary>
@@ -87,10 +91,11 @@ const page = () => {
       </div>
       <div>
         <Pagination
-          totalPosts={40}
-          currentPage={1}
-          pageSize={5}
-          category='meals'
+          limit={limit}
+          page={page}
+          setPage={setPage}
+          totalPosts={26}
+          // setSelection={setSelection}
         />
       </div>
     </div>

--- a/src/components/common/Button/Button.variant.tsx
+++ b/src/components/common/Button/Button.variant.tsx
@@ -11,6 +11,7 @@ export const buttonVariants = cva(
           'bg-gray-100 text-dark-100 hover:bg-gray-200 active:bg-gray-300',
         outline:
           'text-green-700 border-[1px] border-solid border-green-700 hover:border-green-800 hover:text-green-800 active:border-green-900 active:text-green-900',
+        pagination: '',
       },
       size: {
         small: 'py-2 px-4 text-xs',
@@ -27,5 +28,12 @@ export const buttonVariants = cva(
       size: 'basic',
       width: 'full',
     },
+    compoundVariants: [
+      {
+        variant: 'pagination',
+        className:
+          'flex w-7 h-7 p-0 cursor-pointer items-center justify-center rounded bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200 active:bg-green-400',
+      },
+    ],
   },
 );

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -1,74 +1,113 @@
-import Link from 'next/link';
-import Icon from '../Icon';
-import { CAL_PAGE_NUM } from '@/constants/_pagination';
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@/utils/core';
 
 interface Props {
+  limit: number;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
   totalPosts: number;
-  currentPage: number;
-  pageSize: number;
-  category: string;
+  // setSelection: Dispatch<SetStateAction<Set<unknown>>>;
 }
 
-const Pagination = ({ totalPosts, currentPage, pageSize, category }: Props) => {
-  const totalPages = Math.ceil(totalPosts / pageSize);
+const Pagination = ({
+  limit,
+  page,
+  setPage,
+  totalPosts,
+  // setSelection,
+}: Props) => {
+  const [blockNum, setBlockNum] = useState(0);
+  const pageLimit = 5;
+  const blockArea = Number(blockNum * pageLimit);
+  const totalPages = Math.ceil(totalPosts / limit);
+  const createArr = Array(totalPages)
+    .fill(0)
+    .map((_, i) => (
+      <button
+        key={i + 1}
+        onClick={() => {
+          setPage(i + 1);
+          // setSelection(new Set());
+        }}
+        aria-current={page === i + 1 ? 'page' : undefined}
+        className={cn(
+          'flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100',
+          page === i + 1 ? 'bg-green-400' : '',
+        )}
+      >
+        {i + 1}
+      </button>
+    ));
 
-  const floorFive = pageSize * Math.floor(currentPage / pageSize);
-  const ceilFive = pageSize * Math.ceil(currentPage / pageSize);
+  const sliceArr = createArr.slice(blockArea, Number(pageLimit) + blockArea);
 
-  const prevPage = floorFive - CAL_PAGE_NUM.FIRST_PAGE;
-  const nextPage = ceilFive + CAL_PAGE_NUM.LAST_PAGE;
+  const firstPage = () => {
+    setPage(1);
+    setBlockNum(0);
+    // setSelection(new Set());
+  };
 
-  const startPage = ceilFive - CAL_PAGE_NUM.FIRST_PAGE;
+  const lastPage = () => {
+    setPage(totalPages);
+    setBlockNum(Math.ceil(totalPages / pageLimit) - 1);
+    // setSelection(new Set());
+  };
 
-  const generatePageLinks = (currentPage: number) => {
-    const links = [];
-
-    const lastPage =
-      totalPages >= ceilFive ? startPage + CAL_PAGE_NUM.FIRST_PAGE : totalPages;
-    for (let i = startPage; i <= lastPage; i++) {
-      links.push(
-        <Link
-          key={i}
-          href={{
-            pathname: `${category}`,
-            query: { page: `${i}` },
-          }}
-          className={`mx-1 w-10 rounded-full p-2 text-center hover:bg-green-100 hover:text-dark-200 ${
-            i === currentPage ? 'bg-green-100 text-dark-200' : ''
-          }`}
-        >
-          {i}
-        </Link>,
-      );
+  const prevBtnHandler = () => {
+    if (page <= 1) {
+      return;
     }
-    return links;
+    if (page - 1 <= pageLimit * blockNum) {
+      setBlockNum((num) => num - 1);
+      // setSelection(new Set());
+    }
+    setPage((num) => num - 1);
+  };
+
+  const nextBtnHandler = () => {
+    if (page >= totalPages) {
+      return;
+    }
+    if (pageLimit * Number(blockNum + 1) < Number(page + 1)) {
+      setBlockNum((num) => num + 1);
+      // setSelection(new Set());
+    }
+    setPage((num) => num + 1);
   };
 
   return (
-    <div className='flex items-center justify-center p-2'>
-      {!(currentPage <= pageSize) && (
-        <Link
-          className='m-2 flex justify-center rounded-full p-2 text-center hover:bg-green-100'
-          href={{
-            pathname: `/${category}`,
-            query: { page: `${prevPage}` },
-          }}
-        >
-          <Icon name='arrowPrev' width={15} height={15} />
-        </Link>
-      )}
-      {generatePageLinks(currentPage)}
-      {!(totalPages < ceilFive) && (
-        <Link
-          className='m-2 flex justify-center rounded-full p-2 text-center hover:bg-green-100'
-          href={{
-            pathname: `/${category}`,
-            query: { page: `${nextPage}` },
-          }}
-        >
-          <Icon name='arrowNext' width={15} height={15} />
-        </Link>
-      )}
+    <div className='flex w-full items-center justify-center gap-2'>
+      <button
+        onClick={firstPage}
+        disabled={blockNum === 0}
+        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+      >
+        <span className=''>&lt;&lt;</span>
+      </button>
+      <button
+        onClick={prevBtnHandler}
+        disabled={page === 1}
+        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+      >
+        &lt;
+      </button>
+      {sliceArr}
+      <button
+        onClick={nextBtnHandler}
+        disabled={page === totalPages}
+        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+      >
+        &gt;
+      </button>
+      <button
+        onClick={lastPage}
+        disabled={blockArea >= totalPages - 5}
+        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+      >
+        &gt;&gt;
+      </button>
     </div>
   );
 };

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { cn } from '@/utils/core';
+import Button from '../Button/Button';
 
 interface Props {
   limit: number;
@@ -25,20 +26,18 @@ const Pagination = ({
   const createArr = Array(totalPages)
     .fill(0)
     .map((_, i) => (
-      <button
+      <Button
         key={i + 1}
-        onClick={() => {
-          setPage(i + 1);
-          // setSelection(new Set());
-        }}
+        onClick={() => setPage(i + 1)}
         aria-current={page === i + 1 ? 'page' : undefined}
+        variant={'pagination'}
         className={cn(
-          'flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100',
-          page === i + 1 ? 'bg-green-400' : '',
+          '',
+          page === i + 1 ? 'bg-green-400 hover:bg-green-400' : '',
         )}
       >
         {i + 1}
-      </button>
+      </Button>
     ));
 
   const sliceArr = createArr.slice(blockArea, Number(pageLimit) + blockArea);
@@ -79,35 +78,35 @@ const Pagination = ({
 
   return (
     <div className='flex w-full items-center justify-center gap-2'>
-      <button
+      <Button
         onClick={firstPage}
         disabled={blockNum === 0}
-        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+        variant={'pagination'}
       >
-        <span className=''>&lt;&lt;</span>
-      </button>
-      <button
+        <span className='pb-[2px]'>&lt;&lt;</span>
+      </Button>
+      <Button
         onClick={prevBtnHandler}
         disabled={page === 1}
-        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+        variant={'pagination'}
       >
-        &lt;
-      </button>
+        <span className='pb-[2px]'>&lt;</span>
+      </Button>
       {sliceArr}
-      <button
+      <Button
         onClick={nextBtnHandler}
         disabled={page === totalPages}
-        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+        variant={'pagination'}
       >
-        &gt;
-      </button>
-      <button
+        <span className='pb-[2px]'>&gt;</span>
+      </Button>
+      <Button
         onClick={lastPage}
         disabled={blockArea >= totalPages - 5}
-        className='flex h-7 w-7 cursor-pointer items-center justify-center rounded-[4px] bg-green-200 text-center text-white-100 hover:bg-green-300 disabled:cursor-default disabled:hover:bg-green-200'
+        variant={'pagination'}
       >
-        &gt;&gt;
-      </button>
+        <span className='pb-[2px]'>&gt;&gt;</span>
+      </Button>
     </div>
   );
 };


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- block당 페이지 페이지네이션 기능
- 가장 앞페이지와 가장 뒷페이지로 이동 기능

### 설명 (선택)

추후에 정할 페이지당 컨텐츠와, 한 block에 몇개의 페이지버튼을 넣을건지 확정을 지을때까진 해당 파일 내에서 변수 선언하겠습니다
각 페이지의 버튼을 누르거나, prev, next버튼을 이용해 이전, 다음 페이지로 이동하고,
제일 처음 페이지, 제일 마지막 페이지로 이동하는 버튼까지 해두었습니다. 

## 스크린샷

![스크린샷 2024-09-04 오후 10 31 19](https://github.com/user-attachments/assets/8d806702-761f-4b0f-9123-f584a7791b0c)


## 리뷰 요구사항

- 변수명은 어떻게 사용할지 확정짓고 외부로 빼겠습니다! 참고부탁드립니다
