### PR TITLE
Fix[#THKV-34] : Toast 컴포넌트 1초 2초 애니메이션 추가

### DIFF
--- a/src/app/woorim/page.tsx
+++ b/src/app/woorim/page.tsx
@@ -126,11 +126,11 @@ const page = () => {
   const showToast = useToastStore((state) => state.showToast); // eslint-disable-line react-hooks/rules-of-hooks
 
   const handleSuccess = () => {
-    showToast('Operation successful!', 'success', 3000);
+    showToast('Operation successful!', 'success', 1000);
   };
 
   const handleFailure = () => {
-    showToast('Operation failed!', 'warning', 3000);
+    showToast('Operation failed!', 'warning', 2000);
   };
 
   const handleNormal = () => {

--- a/src/components/common/Toast/Toast.variant.tsx
+++ b/src/components/common/Toast/Toast.variant.tsx
@@ -7,5 +7,14 @@ export const progressVariants = cva('h-full origin-left animate-shrink', {
       success: 'bg-blue-200',
       warning: 'bg-red-200',
     },
+    duration: {
+      '1000': 'animate-shrink-1s',
+      '2000': 'animate-shrink-2s',
+      '3000': 'animate-shrink-3s',
+    },
+  },
+  defaultVariants: {
+    variant: 'normal',
+    duration: '3000',
   },
 });

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -12,11 +12,13 @@ export type ToastVariant = NonNullable<
 type ToastProps = {
   message: string;
   variant: ToastVariant;
-  duration: number;
+  duration?: number;
   onClose: () => void;
 };
 
-const Toast = ({ message, variant, duration, onClose }: ToastProps) => {
+export type AnimateDuration = '1000' | '2000' | '3000';
+
+const Toast = ({ message, variant, duration = 3000, onClose }: ToastProps) => {
   useEffect(() => {
     const timer = setTimeout(() => {
       onClose();
@@ -32,7 +34,12 @@ const Toast = ({ message, variant, duration, onClose }: ToastProps) => {
         <span>{message}</span>
       </div>
       <div className='h-1.5 w-full overflow-hidden rounded-full bg-gray-200'>
-        <div className={progressVariants({ variant })} />
+        <div
+          className={progressVariants({
+            variant,
+            duration: `${duration}` as AnimateDuration,
+          })}
+        />
       </div>
     </div>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -15,7 +15,9 @@ const config: Config = {
         '-1/2': '-50%',
       },
       animation: {
-        shrink: 'shrink 3s linear forwards',
+        'shrink-1s': 'shrink 1s linear forwards',
+        'shrink-2s': 'shrink 2s linear forwards',
+        'shrink-3s': 'shrink 3s linear forwards',
       },
       keyframes: {
         shrink: {


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- Toast prop인 duration을 사용해 1초 2초 3초에 맞는 애니메이션 구현
- tailwind config에 각 초별 애니메이션 키값 등록 후 variant에서 duration과 연결해 사용

### 설명 (선택)

- 전에 승현님이 제안주신 방식으로 `tailwind config`에서 `animation-shrink` 를 그냥 두고, `duration`만 사용하여 구현하려했지만 아래와 같은 이상 현상이 발생하여 지금 방식으로 수정하여 PR 올립니다.
- [이상 현상] `duration`을 `classname='animate-shrink duration-1000'`와 같이 주었지만, 
config에서 설정한 animate-shirnk의 3s로 작동하여 
toast는 1초만에 닫히지만, progress bar는 3초에 맞는 속도로 천천히 줄어들어 progress bar가 다 줄어들기 전에 toast 창이 사라지는 현상

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
