### PR TITLE
Feat[#THKV-35]: MealHeader 구현 및 SelectBox 관련 버그 수정

### DIFF
--- a/src/app/woorim/page.tsx
+++ b/src/app/woorim/page.tsx
@@ -7,6 +7,9 @@ import Icon from '@/components/common/Icon';
 // import Navbar from '@/components/common/Navbar';
 import { Option, Selectbox } from '@/components/common/Selectbox';
 import Table from '@/components/common/Table';
+import MealHeader, {
+  schoolCategory,
+} from '@/components/shared/Meal/MealHeader';
 import { useToastStore } from '@/stores/useToastStore';
 
 // 테이블 예시 데이터
@@ -137,8 +140,28 @@ const page = () => {
     showToast('This is a normal message', 'normal');
   };
 
+  const categories = [
+    schoolCategory,
+    [
+      { value: '하이', label: '하이' },
+      { value: '학교명', label: '학교명' },
+      { value: '병원', label: '병원' },
+    ],
+    [
+      { value: '세번쨰', label: '세번쨰' },
+      { value: '학교명', label: '학교명' },
+      { value: '병원', label: '병원' },
+      { value: '세번쨰', label: '세번쨰' },
+      { value: '학교명', label: '학교명' },
+      { value: '병원', label: '병원' },
+      { value: '세번쨰', label: '세번쨰' },
+      { value: '학교명', label: '학교명' },
+      { value: '병원', label: '병원' },
+    ],
+  ];
   return (
-    <div className='flex h-full w-full flex-col gap-4 bg-blue-200'>
+    <div className='flex h-full w-full flex-col gap-4 bg-blue-100'>
+      <MealHeader name='식단 이름' categories={categories} />
       <div className='bg-gray-100'>
         <button onClick={handleNormal}>Show Normal Toast</button>
         <button onClick={handleSuccess}>Show Success Toast</button>

--- a/src/app/woorim/page.tsx
+++ b/src/app/woorim/page.tsx
@@ -8,7 +8,7 @@ import Icon from '@/components/common/Icon';
 import { Option, Selectbox } from '@/components/common/Selectbox';
 import Table from '@/components/common/Table';
 import MealHeader, {
-  schoolCategory,
+  schoolLevelList,
 } from '@/components/shared/Meal/MealHeader';
 import { useToastStore } from '@/stores/useToastStore';
 
@@ -141,7 +141,7 @@ const page = () => {
   };
 
   const categories = [
-    schoolCategory,
+    schoolLevelList,
     [
       { value: '하이', label: '하이' },
       { value: '학교명', label: '학교명' },

--- a/src/components/common/Dropdown/Dropdown.variant.tsx
+++ b/src/components/common/Dropdown/Dropdown.variant.tsx
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const dropdownVariants = cva(
-  'absolute z-10 w-full max-h-56 overflow-y-scroll custom-scrollbar bg-white-100 border-[1px] border-red rounded-md shadow-md',
+  'absolute z-10 w-full max-h-56 overflow-y-auto custom-scrollbar bg-white-100 border-[1px] border-red rounded-md shadow-md',
   {
     variants: {
       isOpen: {

--- a/src/components/common/OptionList/OptionList.variant.tsx
+++ b/src/components/common/OptionList/OptionList.variant.tsx
@@ -8,10 +8,6 @@ export const optionListUlVariants = cva('flex h-full w-full flex-col', {
         'pl-[10px] pt-[10px] pb-[10px] pr-[5px] gap-2 text-basic rounded-lg',
       large: 'pl-3 pt-3 pb-3 pr-[6px] gap-2 text-lg rounded-lg',
     },
-    isNoScroll: {
-      true: '',
-      false: '',
-    },
   },
 });
 

--- a/src/components/common/OptionList/OptionList.variant.tsx
+++ b/src/components/common/OptionList/OptionList.variant.tsx
@@ -1,11 +1,29 @@
 import { cva } from 'class-variance-authority';
 
-export const optionListVariants = cva('flex h-full w-full flex-col', {
+export const optionListUlVariants = cva('flex h-full w-full flex-col', {
   variants: {
     size: {
-      small: 'pl-2 pt-2 pb-2 py-2 gap-1 text-sm rounded-md',
-      basic: 'pl-[10px] pt-[10px] pb-[10px] py-3 gap-2 text-basic rounded-lg',
-      large: 'pl-3 pt-3 pb-3 py-4 gap-2 text-lg rounded-lg',
+      small: 'pl-2 pt-2 pb-2 pr-1 gap-1 text-sm rounded-md',
+      basic:
+        'pl-[10px] pt-[10px] pb-[10px] pr-[5px] gap-2 text-basic rounded-lg',
+      large: 'pl-3 pt-3 pb-3 pr-[6px] gap-2 text-lg rounded-lg',
+    },
+    isNoScroll: {
+      true: '',
+      false: '',
     },
   },
 });
+
+export const optionListLiVariants = cva(
+  'cursor-pointer rounded-md hover:bg-gray-100 active:bg-gray-200',
+  {
+    variants: {
+      size: {
+        small: 'pt-2 pb-2 pl-2 mr-1 gap-1 text-sm rounded-md',
+        basic: 'p-[10px] mr-[5px] gap-2 text-basic rounded-lg ',
+        large: 'pl-3 mr-[6px] pt-3 pb-3 py-4 gap-2 text-lg rounded-lg',
+      },
+    },
+  },
+);

--- a/src/components/common/OptionList/index.tsx
+++ b/src/components/common/OptionList/index.tsx
@@ -1,5 +1,7 @@
-import { cn } from '@/utils/core';
-import { optionListVariants } from '@/components/common/OptionList/OptionList.variant';
+import {
+  optionListLiVariants,
+  optionListUlVariants,
+} from '@/components/common/OptionList/OptionList.variant';
 import { Option, Size } from '@/components/common/Selectbox';
 
 type OptionListProps = {
@@ -9,14 +11,11 @@ type OptionListProps = {
 };
 
 const OptionList = ({ options, size, onSelect }: OptionListProps) => (
-  <ul className={optionListVariants({ size })} role='listbox'>
+  <ul className={optionListUlVariants({ size })} role='listbox'>
     {options.map((option) => (
       <li
         key={option.value}
-        className={cn(
-          optionListVariants({ size }),
-          'cursor-pointer rounded-md hover:bg-gray-100 active:bg-gray-200',
-        )}
+        className={optionListLiVariants({ size })}
         onClick={() => onSelect(option.value)}
       >
         {option.label}

--- a/src/components/common/SelectButton/SelectButton.variant.tsx
+++ b/src/components/common/SelectButton/SelectButton.variant.tsx
@@ -1,13 +1,13 @@
 import { cva } from 'class-variance-authority';
 
 export const selectButtonVariants = cva(
-  'w-full border-[1px] border-gray-300 rounded-md bg-white-200 text-left focus:border-green-700 focus:outline-none',
+  'w-fit border-[1px] border-gray-300 rounded-md bg-white-200 text-left focus:border-green-700 focus:outline-none',
   {
     variants: {
       size: {
-        small: 'px-3 py-2 text-sm rounded-md pr-8',
-        basic: 'px-5 py-3 text-basic rounded-lg pr-10',
-        large: 'px-7 py-5 text-lg rounded-lg pr-12',
+        small: 'min-w-20 px-3 py-2 text-sm rounded-md pr-8',
+        basic: 'min-w-24 px-5 py-3 text-basic rounded-lg pr-10',
+        large: 'min-w-28 px-7 py-5 text-lg rounded-lg pr-12',
       },
     },
   },

--- a/src/components/common/Typography/Typography.variant.tsx
+++ b/src/components/common/Typography/Typography.variant.tsx
@@ -22,7 +22,8 @@ export const typographyVariants = cva(
         caption1: 'text-[12px] leading-[155%]',
         caption2: 'text-[8px] leading-[155%]',
         question: 'text-[22px] leading-[145%]',
-        authTitle: 'text-[50px] leadiing-[150%]',
+        mealHeaderTitle: 'text-[42px] leading-[150%]',
+        authTitle: 'text-[50px] leading-[150%]',
       },
       weight: {
         bold: 'font-bold',

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -42,3 +42,8 @@ export const AuthTitle = customTypography('h1', {
   type: 'authTitle',
   weight: 'bold',
 });
+export const MealHeaderTitle = customTypography('h1', {
+  type: 'mealHeaderTitle',
+  weight: 'bold',
+  color: 'dark',
+});

--- a/src/components/shared/Meal/MealHeader/index.tsx
+++ b/src/components/shared/Meal/MealHeader/index.tsx
@@ -7,13 +7,13 @@ type MealHeaderProps = {
   categories: Option[][];
 };
 
-export const organizationCategory = [
+export const organizationList = [
   { value: '학교', label: '학교' },
   { value: '학교명', label: '학교명' },
   { value: '병원', label: '병원' },
 ];
 
-export const schoolCategory = [
+export const schoolLevelList = [
   { value: '초등학교', label: '초등학교' },
   { value: '중학교', label: '중학교' },
   { value: '고등학교', label: '고등학교' },
@@ -22,8 +22,8 @@ export const schoolCategory = [
 const MealHeader = ({ name, categories }: MealHeaderProps) => {
   const [organization, setOrganization] = useState<null | string>(null);
 
-  const onOrganizationChange = (value: string) => {
-    setOrganization(value);
+  const onOrganizationChange = (organization: string) => {
+    setOrganization(organization);
   };
 
   return (
@@ -31,18 +31,19 @@ const MealHeader = ({ name, categories }: MealHeaderProps) => {
       <MealHeaderTitle>{name}</MealHeaderTitle>
       <div className='flex gap-2'>
         <Selectbox
-          options={organizationCategory}
+          options={organizationList}
           size='basic'
-          onChange={(value) => onOrganizationChange(value)}
+          onChange={(organization) => onOrganizationChange(organization)}
         />
-        {organization === '학교' && (
-          <Selectbox options={categories[0]} size='basic' />
-        )}
-        {organization === '학교명' && (
-          <Selectbox options={categories[1]} size='basic' />
-        )}
-        {organization === '병원' && (
-          <Selectbox options={categories[2]} size='basic' />
+        {organizationList.map(
+          (item, index) =>
+            organization === item.value && (
+              <Selectbox
+                key={item.value}
+                options={categories[index]}
+                size='basic'
+              />
+            ),
         )}
       </div>
     </div>

--- a/src/components/shared/Meal/MealHeader/index.tsx
+++ b/src/components/shared/Meal/MealHeader/index.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+import { Option, Selectbox } from '@/components/common/Selectbox';
+import { MealHeaderTitle } from '@/components/common/Typography';
+
+type MealHeaderProps = {
+  name: string;
+  categories: Option[][];
+};
+
+export const organizationCategory = [
+  { value: '학교', label: '학교' },
+  { value: '학교명', label: '학교명' },
+  { value: '병원', label: '병원' },
+];
+
+export const schoolCategory = [
+  { value: '초등학교', label: '초등학교' },
+  { value: '중학교', label: '중학교' },
+  { value: '고등학교', label: '고등학교' },
+];
+
+const MealHeader = ({ name, categories }: MealHeaderProps) => {
+  const [organization, setOrganization] = useState<null | string>(null);
+
+  const onOrganizationChange = (value: string) => {
+    setOrganization(value);
+  };
+
+  return (
+    <div className='flex w-full flex-col gap-8 px-14 py-10'>
+      <MealHeaderTitle>{name}</MealHeaderTitle>
+      <div className='flex gap-2'>
+        <Selectbox
+          options={organizationCategory}
+          size='basic'
+          onChange={(value) => onOrganizationChange(value)}
+        />
+        {organization === '학교' && (
+          <Selectbox options={categories[0]} size='basic' />
+        )}
+        {organization === '학교명' && (
+          <Selectbox options={categories[1]} size='basic' />
+        )}
+        {organization === '병원' && (
+          <Selectbox options={categories[2]} size='basic' />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MealHeader;


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 식단 페이지에서 공통으로 사용하는 MealHeader 구현



### 설명 (선택)
#### MealHeader 
- `categories` : 첫 번째 카테고리 선택에 따라 보여줄 두 번째 카테고리 값들을 배열로 받습니다.
- 데이터가 어떤 식으로 올지 아직 몰라서 임시로 구현해두었고, 추후 데이터에 맞게 수정할 예정입니다.
- 첫 번째 카테고리를 선택해야만 두 번째 Selectbox가 보이게 구현하였고, 이를 위해 state를 사용했습니다.

#### fix
- SelectButton min width 추가
- Dropdown overflow-y auto 수정
- Typography varinats typo 수정

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
![image](https://github.com/user-attachments/assets/cc6788eb-c505-4dd4-bb8b-4ddc2857145e)

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
