### PR TITLE
Feat[THKV-37]: 식단 조회 리스트 페이지 작성

### DIFF
--- a/src/app/(root)/Layout.tsx
+++ b/src/app/(root)/Layout.tsx
@@ -4,7 +4,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className='flex min-h-screen'>
       <Navbar />
-      <main className='ml-60 flex-grow p-6'>{children}</main>
+      <main className='ml-60 flex-grow bg-white-200 p-6'>{children}</main>
     </div>
   );
 };

--- a/src/app/(root)/viewPlan/page.tsx
+++ b/src/app/(root)/viewPlan/page.tsx
@@ -1,0 +1,7 @@
+import ViewPlan from '@/components/feature/ViewPlan';
+
+const page = () => {
+  return <ViewPlan />;
+};
+
+export default page;

--- a/src/components/common/ControlTab/index.tsx
+++ b/src/components/common/ControlTab/index.tsx
@@ -19,7 +19,7 @@ const ControlTab = <T extends string>({
           key={tab}
           className={cn(
             'text-xs text-gray-400',
-            tab === selectedTab && 'font-semibold text-gray-600',
+            tab === selectedTab && 'font-semibold text-green-600',
           )}
           onClick={() => setSelectedTab(tab)}
         >

--- a/src/components/common/ControlTab/index.tsx
+++ b/src/components/common/ControlTab/index.tsx
@@ -18,7 +18,7 @@ const ControlTab = <T extends string>({
         <button
           key={tab}
           className={cn(
-            'text-sm text-gray-400',
+            'text-xs text-gray-400',
             tab === selectedTab && 'font-semibold text-gray-600',
           )}
           onClick={() => setSelectedTab(tab)}

--- a/src/components/common/DatePicker/index.tsx
+++ b/src/components/common/DatePicker/index.tsx
@@ -28,7 +28,7 @@ const DatePicker = ({
   }));
 
   return (
-    <div className='flex items-center gap-2'>
+    <div className='flex w-full items-center gap-2'>
       <div className='flex flex-col gap-1'>
         <label className='text-xs'>년도</label>
         <Selectbox

--- a/src/components/common/DatePicker/index.tsx
+++ b/src/components/common/DatePicker/index.tsx
@@ -28,7 +28,7 @@ const DatePicker = ({
   }));
 
   return (
-    <div className='flex w-full items-center gap-2'>
+    <div className='flex items-center gap-2'>
       <div className='flex flex-col gap-1'>
         <label className='text-xs'>년도</label>
         <Selectbox

--- a/src/components/common/Icon/assets/Search.tsx
+++ b/src/components/common/Icon/assets/Search.tsx
@@ -1,33 +1,19 @@
 import { SVGProps } from 'react';
 
-const Search = ({
-  width,
-  height,
-  color,
-  ...props
-}: SVGProps<SVGSVGElement>) => {
+const Search = ({ width, height, color }: SVGProps<SVGSVGElement>) => {
   return (
     <svg
       width={width}
       height={height}
-      viewBox='0 0 24 24'
+      viewBox='0 0 16 16'
       fill='none'
       xmlns='http://www.w3.org/2000/svg'
-      {...props}
+      color={color}
     >
-      <circle
-        cx='11.7666'
-        cy='11.7666'
-        r='8.98856'
-        stroke={color}
-        strokeWidth='1.5'
-        strokeLinecap='round'
-        strokeLinejoin='round'
-      />
       <path
-        d='M18.0183 18.4852L21.5423 22.0001'
-        stroke={color}
-        strokeWidth='1.5'
+        d='M14.7506 14.7506L10.8528 10.8528M10.8528 10.8528C11.9078 9.7979 12.5004 8.36711 12.5004 6.87521C12.5004 5.38331 11.9078 3.95252 10.8528 2.89759C9.7979 1.84265 8.36711 1.25 6.87521 1.25C5.38331 1.25 3.95252 1.84265 2.89759 2.89759C1.84265 3.95252 1.25 5.38331 1.25 6.87521C1.25 8.36711 1.84265 9.7979 2.89759 10.8528C3.95252 11.9078 5.38331 12.5004 6.87521 12.5004C8.36711 12.5004 9.7979 11.9078 10.8528 10.8528Z'
+        stroke='currentColor'
+        strokeWidth='1'
         strokeLinecap='round'
         strokeLinejoin='round'
       />

--- a/src/components/common/Input/Input.variant.tsx
+++ b/src/components/common/Input/Input.variant.tsx
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const inputContainerVariants = cva(
-  'flex w-full items-center gap-2 border p-4',
+  'flex w-full items-center gap-2 border px-2 box-border',
   {
     variants: {
       variant: {
@@ -9,14 +9,14 @@ export const inputContainerVariants = cva(
       },
       bgcolor: {
         form: 'bg-green-100',
-        search: 'bg-white-200',
+        search: 'bg-white-100',
       },
       borderRadius: {
         basic: 'rounded-md',
         large: 'rounded-lg',
       },
       height: {
-        basic: 'h-[36px]',
+        basic: 'h-[38px]',
         large: 'h-[62px]',
       },
       isFocused: {
@@ -36,5 +36,5 @@ export const inputContainerVariants = cva(
 );
 
 export const inputVariants = cva(
-  'w-full bg-transparent text-[14px] placeholder:text-gray-900 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+  'w-full flex items-center bg-transparent text-[14px] placeholder:text-gray-400 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
 );

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -58,7 +58,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const handleFocus = useCallback(() => setIsFocused(true), []);
     const handleBlur = useCallback(() => setIsFocused(false), []);
     return (
-      <div className='flex items-center gap-4'>
+      <div className='flex items-center gap-2'>
         <div
           className={inputContainerVariants({
             isFocused,

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -58,42 +58,40 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const handleFocus = useCallback(() => setIsFocused(true), []);
     const handleBlur = useCallback(() => setIsFocused(false), []);
     return (
-      <div className='flex items-center gap-2'>
-        <div
-          className={inputContainerVariants({
-            isFocused,
-            borderRadius,
-            bgcolor,
-            variant,
-            height,
-            disabled,
-          })}
-        >
-          {isLeftIcon && <Icon name='search' width={15} height={15} />}
-          <input
-            className={cn(inputVariants(), className)}
-            ref={ref}
-            value={value}
-            disabled={disabled}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            {...props}
-          />
-          {isRightIcon && rightIcon && (
-            <button onClick={rightIconAction} type='button'>
-              <Icon
-                name={rightIcon}
-                width={20}
-                height={20}
-                className='cursor-pointer'
-              />
-            </button>
-          )}
-        </div>
+      <div
+        className={inputContainerVariants({
+          isFocused,
+          borderRadius,
+          bgcolor,
+          variant,
+          height,
+          disabled,
+        })}
+      >
+        {isLeftIcon && <Icon name='search' width={22} height={22} />}
+        <input
+          className={cn(inputVariants(), className)}
+          ref={ref}
+          value={value}
+          disabled={disabled}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          {...props}
+        />
+        {isRightIcon && rightIcon && (
+          <button onClick={rightIconAction} type='button'>
+            <Icon
+              name={rightIcon}
+              width={20}
+              height={20}
+              className='cursor-pointer'
+            />
+          </button>
+        )}
         {includeButton && (
           <Button
             onClick={onSubmit}
-            className='w-16 cursor-pointer items-center justify-center rounded'
+            className='w-14 cursor-pointer items-center justify-center rounded px-0 py-1'
             size='small'
             width='fit'
             disabled={disabled || !value}

--- a/src/components/common/Input/index.tsx
+++ b/src/components/common/Input/index.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 import { type VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/core';
+import Button from '../Button/Button';
 import Icon from '../Icon';
 import { inputContainerVariants, inputVariants } from './Input.variant';
 
@@ -90,13 +91,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
           )}
         </div>
         {includeButton && (
-          <button
+          <Button
             onClick={onSubmit}
-            className='w-14 cursor-pointer items-center justify-center rounded bg-white-200'
+            className='w-16 cursor-pointer items-center justify-center rounded'
+            size='small'
+            width='fit'
             disabled={disabled || !value}
           >
             검색
-          </button>
+          </Button>
         )}
       </div>
     );

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -83,14 +83,14 @@ const Pagination = ({
         disabled={blockNum === 0}
         variant={'pagination'}
       >
-        <span className='pb-[2px]'>&lt;&lt;</span>
+        &lt;&lt;
       </Button>
       <Button
         onClick={prevBtnHandler}
         disabled={page === 1}
         variant={'pagination'}
       >
-        <span className='pb-[2px]'>&lt;</span>
+        &lt;
       </Button>
       {sliceArr}
       <Button
@@ -98,14 +98,14 @@ const Pagination = ({
         disabled={page === totalPages}
         variant={'pagination'}
       >
-        <span className='pb-[2px]'>&gt;</span>
+        &gt;
       </Button>
       <Button
         onClick={lastPage}
         disabled={blockArea >= totalPages - 5}
         variant={'pagination'}
       >
-        <span className='pb-[2px]'>&gt;&gt;</span>
+        &gt;&gt;
       </Button>
     </div>
   );

--- a/src/components/feature/ViewPlan/index.tsx
+++ b/src/components/feature/ViewPlan/index.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import GetAllListControls from '@/components/shared/GetAllList/Controls';
+import GetAllListHeader from '@/components/shared/GetAllList/Header';
+import { TAB_OPTIONS } from '@/constants/_controlTab';
+
+const ViewPlan = () => {
+  const [selectedYear, setSelectedYear] = useState<string>(
+    new Date().getFullYear().toString(),
+  );
+  const [selectedMonth, setSelectedMonth] = useState<string>(
+    (new Date().getMonth() + 1).toString(),
+  );
+  const [organization, setOrganization] = useState<null | string>(null);
+  const [selectedTab, setSelectedTab] = useState<string>(TAB_OPTIONS[0]);
+
+  const handleSearchName = () => {
+    console.log('이름 검색');
+  };
+
+  return (
+    <div className='flex flex-col gap-8'>
+      <GetAllListHeader title={'내가 작성한 식단'} />
+      <GetAllListControls
+        type='viewPlan'
+        selectedMonth={selectedMonth}
+        selectedYear={selectedYear}
+        onMonthChange={setSelectedMonth}
+        onYearChange={setSelectedYear}
+        organization={organization}
+        setOrganization={setOrganization}
+        handleSearchName={handleSearchName}
+        selectedTab={selectedTab}
+        setSelectedTab={setSelectedTab}
+      />
+    </div>
+  );
+};
+
+export default ViewPlan;

--- a/src/components/feature/ViewPlan/index.tsx
+++ b/src/components/feature/ViewPlan/index.tsx
@@ -1,9 +1,12 @@
 'use client';
 
 import { useState } from 'react';
+import Pagination from '@/components/common/Pagination';
 import GetAllListControls from '@/components/shared/GetAllList/Controls';
 import GetAllListHeader from '@/components/shared/GetAllList/Header';
+import GetAllListTable from '@/components/shared/GetAllList/ListTable';
 import { TAB_OPTIONS } from '@/constants/_controlTab';
+import { PLAN_DATA } from '@/constants/_getAllList/_planData';
 
 const ViewPlan = () => {
   const [selectedYear, setSelectedYear] = useState<string>(
@@ -12,11 +15,18 @@ const ViewPlan = () => {
   const [selectedMonth, setSelectedMonth] = useState<string>(
     (new Date().getMonth() + 1).toString(),
   );
+  const [searchValue, setSearchValue] = useState('');
   const [organization, setOrganization] = useState<null | string>(null);
   const [selectedTab, setSelectedTab] = useState<string>(TAB_OPTIONS[0]);
+  const [page, setPage] = useState(1);
 
-  const handleSearchName = () => {
-    console.log('이름 검색');
+  const handlechangeSearchValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(e.target.value);
+  };
+
+  const submitSearchValue = () => {
+    // TODO: api request body로 보내줄 식단이름 제출함수
+    console.log('검색 버튼 클릭');
   };
 
   return (
@@ -30,9 +40,18 @@ const ViewPlan = () => {
         onYearChange={setSelectedYear}
         organization={organization}
         setOrganization={setOrganization}
-        handleSearchName={handleSearchName}
+        searchValue={searchValue}
+        handlechangeSearchValue={handlechangeSearchValue}
+        submitSearchValue={submitSearchValue}
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
+      />
+      <GetAllListTable data={PLAN_DATA} />
+      <Pagination
+        limit={8}
+        page={page}
+        setPage={setPage}
+        totalPosts={PLAN_DATA.length}
       />
     </div>
   );

--- a/src/components/shared/GetAllList/Controls/index.tsx
+++ b/src/components/shared/GetAllList/Controls/index.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import ControlTab from '@/components/common/ControlTab';
+import DatePicker from '@/components/common/DatePicker';
+import { Input } from '@/components/common/Input';
+import { Selectbox } from '@/components/common/Selectbox';
+import { TAB_OPTIONS } from '@/constants/_controlTab';
+import { CATEGORIES, ORGANIZATIONS } from '@/constants/_getAllList/_categories';
+
+interface Props {
+  type: 'viewPlan' | 'viewChart';
+  selectedYear: string;
+  selectedMonth: string;
+  onYearChange: (year: string) => void;
+  onMonthChange: (month: string) => void;
+  organization?: string | null;
+  setOrganization?: React.Dispatch<React.SetStateAction<string | null>>;
+  handleSearchName: () => void;
+  selectedTab: string;
+  setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
+}
+
+const GetAllListControls = ({
+  selectedMonth,
+  selectedYear,
+  onMonthChange,
+  onYearChange,
+  organization,
+  setOrganization,
+  handleSearchName,
+  selectedTab,
+  setSelectedTab,
+}: Props) => {
+  return (
+    <>
+      <div className='flex justify-between'>
+        <DatePicker
+          selectedMonth={selectedMonth}
+          selectedYear={selectedYear}
+          onMonthChange={onMonthChange}
+          onYearChange={onYearChange}
+        />
+        <div className='flex items-end gap-5'>
+          <Input
+            isLeftIcon={true}
+            height='basic'
+            placeholder='식단 이름을 입력해주세요.'
+            bgcolor='search'
+            includeButton={true}
+            onSubmit={handleSearchName}
+          />
+          <div className='flex gap-2'>
+            <Selectbox
+              options={ORGANIZATIONS}
+              size='small'
+              onChange={(organization) => setOrganization!(organization)}
+            />
+            {ORGANIZATIONS.map(
+              (item, index) =>
+                organization === item.value && (
+                  <Selectbox
+                    key={item.value}
+                    options={CATEGORIES[index]}
+                    size='small'
+                  />
+                ),
+            )}
+          </div>
+        </div>
+      </div>
+      <div className='flex justify-end'>
+        <ControlTab
+          controlTabItems={TAB_OPTIONS}
+          selectedTab={selectedTab}
+          setSelectedTab={setSelectedTab}
+        />
+      </div>
+    </>
+  );
+};
+
+export default GetAllListControls;

--- a/src/components/shared/GetAllList/Controls/index.tsx
+++ b/src/components/shared/GetAllList/Controls/index.tsx
@@ -44,7 +44,7 @@ const GetAllListControls = ({
           onMonthChange={onMonthChange}
           onYearChange={onYearChange}
         />
-        <div className='flex items-end gap-5'>
+        <div className='flex w-full justify-end gap-5'>
           <Input
             isLeftIcon={true}
             height='basic'
@@ -55,7 +55,7 @@ const GetAllListControls = ({
             onChange={handlechangeSearchValue}
             onSubmit={submitSearchValue}
           />
-          <div className='flex gap-2'>
+          <div className='flex whitespace-pre'>
             <Selectbox
               options={ORGANIZATIONS}
               size='small'

--- a/src/components/shared/GetAllList/Controls/index.tsx
+++ b/src/components/shared/GetAllList/Controls/index.tsx
@@ -15,7 +15,9 @@ interface Props {
   onMonthChange: (month: string) => void;
   organization?: string | null;
   setOrganization?: React.Dispatch<React.SetStateAction<string | null>>;
-  handleSearchName: () => void;
+  searchValue: string;
+  handlechangeSearchValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  submitSearchValue: () => void;
   selectedTab: string;
   setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
 }
@@ -27,7 +29,9 @@ const GetAllListControls = ({
   onYearChange,
   organization,
   setOrganization,
-  handleSearchName,
+  searchValue,
+  handlechangeSearchValue,
+  submitSearchValue,
   selectedTab,
   setSelectedTab,
 }: Props) => {
@@ -47,7 +51,9 @@ const GetAllListControls = ({
             placeholder='식단 이름을 입력해주세요.'
             bgcolor='search'
             includeButton={true}
-            onSubmit={handleSearchName}
+            value={searchValue}
+            onChange={handlechangeSearchValue}
+            onSubmit={submitSearchValue}
           />
           <div className='flex gap-2'>
             <Selectbox

--- a/src/components/shared/GetAllList/Header/index.tsx
+++ b/src/components/shared/GetAllList/Header/index.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { MealHeaderTitle } from '@/components/common/Typography';
+
+interface Props {
+  title: string;
+}
+
+const ViewPlanHeader = ({ title }: Props) => {
+  return (
+    <>
+      <MealHeaderTitle>{title}</MealHeaderTitle>
+    </>
+  );
+};
+
+export default ViewPlanHeader;

--- a/src/components/shared/GetAllList/ListTable/index.tsx
+++ b/src/components/shared/GetAllList/ListTable/index.tsx
@@ -1,0 +1,11 @@
+import Table, { TableRowData } from '@/components/common/Table';
+
+interface Props {
+  data: TableRowData[];
+}
+
+const GetAllListTable = ({ data }: Props) => {
+  return <Table data={data} type='list' />;
+};
+
+export default GetAllListTable;

--- a/src/constants/_controlTab.ts
+++ b/src/constants/_controlTab.ts
@@ -1,0 +1,1 @@
+export const TAB_OPTIONS = ['최신순', '오래된 순'];

--- a/src/constants/_getAllList/_categories.ts
+++ b/src/constants/_getAllList/_categories.ts
@@ -1,0 +1,29 @@
+export const ORGANIZATIONS = [
+  { value: '학교', label: '학교' },
+  { value: '학교명', label: '학교명' },
+  { value: '병원', label: '병원' },
+];
+
+export const CATEGORIES = [
+  [
+    { value: '초등학교', label: '초등학교' },
+    { value: '중학교', label: '중학교' },
+    { value: '고등학교', label: '고등학교' },
+  ],
+  [
+    { value: '학교명1', label: '학교명1' },
+    { value: '학교명2', label: '학교명2' },
+    { value: '학교명3', label: '학교명3' },
+  ],
+  [
+    { value: '병원1', label: '병원1' },
+    { value: '병원2', label: '병원2' },
+    { value: '병원3', label: '병원3' },
+    { value: '병원4', label: '병원4' },
+    { value: '병원5', label: '병원5' },
+    { value: '병원6', label: '병원6' },
+    { value: '병원7', label: '병원7' },
+    { value: '병원8', label: '병원8' },
+    { value: '병원9', label: '병원9' },
+  ],
+];

--- a/src/constants/_getAllList/_planData.ts
+++ b/src/constants/_getAllList/_planData.ts
@@ -1,0 +1,38 @@
+export const PLAN_DATA = [
+  {
+    id: 1,
+    title: '식단이름1',
+    createdAt: '2024.09.14',
+    category: '초등학교',
+  },
+  {
+    id: 2,
+    title: '식단이름2',
+    createdAt: '2024.09.14',
+    category: '중학교',
+  },
+  {
+    id: 3,
+    title: '식단이름3',
+    createdAt: '2024.09.14',
+    category: '고등학교',
+  },
+  {
+    id: 4,
+    title: '식단이름4',
+    createdAt: '2024.09.14',
+    category: '중학교',
+  },
+  {
+    id: 5,
+    title: '식단이름5',
+    createdAt: '2024.09.14',
+    category: '고등학교',
+  },
+  {
+    id: 6,
+    title: '식단이름6',
+    createdAt: '2024.09.14',
+    category: '초등학교',
+  },
+];

--- a/src/constants/_getAllList/_planData.ts
+++ b/src/constants/_getAllList/_planData.ts
@@ -35,4 +35,16 @@ export const PLAN_DATA = [
     createdAt: '2024.09.14',
     category: '초등학교',
   },
+  {
+    id: 7,
+    title: '식단이름7',
+    createdAt: '2024.09.14',
+    category: '고등학교',
+  },
+  {
+    id: 8,
+    title: '식단이름8',
+    createdAt: '2024.09.14',
+    category: '초등학교',
+  },
 ];


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- [UI] 식단 조회 리스트 페이지

### 설명 (선택)

설문 조회 리스트와 같은 shared 컴포넌트로 사용하기 위해
shared에 헤더, 컨트롤, 테이블로 나누어서 개발 진행

## 스크린샷

![스크린샷 2024-09-14 오후 11 54 43](https://github.com/user-attachments/assets/0423de73-7aa7-4c72-b01f-828247e97c64)

## 리뷰 요구사항

- GetAllListControls 컴포넌트에서 organization,  setOrganization props만 옵셔널로 준 이유는 설문 조회 페이지에서도 가져다 쓸 컴포넌트이고, 다른 props는 설문 조회 페이지에서도 활용하지만, 해당 두개의 props는 사용하지 않기 때문에 옵셔널 주었습니다!
설문 페이지 작업할때는 진행중 / 마감 상태와 마감일을 옵셔널로 하여 props 넘겨줄 생각입니다