### PR TITLE
Feat[#THKV-38] : 자동 식단 페이지 구현 /autoPlan 

### DIFF
--- a/src/app/(root)/autoPlan/page.tsx
+++ b/src/app/(root)/autoPlan/page.tsx
@@ -1,0 +1,7 @@
+import AutoPlan from '@/components/feature/AutoPlan';
+
+const page = () => {
+  return <AutoPlan />;
+};
+
+export default page;

--- a/src/components/common/Typography/Typography.variant.tsx
+++ b/src/components/common/Typography/Typography.variant.tsx
@@ -24,6 +24,7 @@ export const typographyVariants = cva(
         question: 'text-[22px] leading-[145%]',
         mealHeaderTitle: 'text-[42px] leading-[150%]',
         authTitle: 'text-[50px] leading-[150%]',
+        mealCalendarTitle: 'text-[36px] leading-[155%]',
       },
       weight: {
         bold: 'font-bold',

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -47,3 +47,7 @@ export const MealHeaderTitle = customTypography('h1', {
   weight: 'bold',
   color: 'dark',
 });
+export const MealCalenderTitle = customTypography('h1', {
+  type: 'mealCalendarTitle',
+  color: 'dark',
+});

--- a/src/components/feature/AutoPlan/index.tsx
+++ b/src/components/feature/AutoPlan/index.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { mealHeaderSchema } from '@/schema/mealSchema';
+import MealCalendar from '@/components/shared/Meal/MealCalender';
+import MealHeader, {
+  schoolLevelList,
+} from '@/components/shared/Meal/MealHeader';
+
+const categories = [
+  schoolLevelList,
+  [
+    { value: '학교', label: '학교' },
+    { value: '학교명', label: '학교명' },
+    { value: '병원', label: '병원' },
+  ],
+  [
+    { value: '세번쨰', label: '세번쨰' },
+    { value: '학교명', label: '학교명' },
+    { value: '병원', label: '병원' },
+    { value: '세번쨰', label: '세번쨰' },
+    { value: '학교명', label: '학교명' },
+    { value: '병원', label: '병원' },
+    { value: '세번쨰', label: '세번쨰' },
+    { value: '학교명', label: '학교명' },
+    { value: '병원', label: '병원' },
+  ],
+];
+
+const now = new Date();
+const year = now.getFullYear();
+const month = now.getMonth() + 1;
+
+const AutoPlan = () => {
+  const [selectedCategory, setSelectedCategory] = useState({
+    organization: null as string | null,
+    organizationDetail: null as string | null,
+  });
+  const isCategoryEmpty = !(
+    selectedCategory.organization || selectedCategory.organizationDetail
+  );
+
+  const dataClick = (date: string) => {
+    console.log(date);
+  };
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm({
+    resolver: zodResolver(mealHeaderSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+    },
+  });
+
+  const handleCategoryChange = (
+    type: 'organization' | 'organizationDetail',
+    value: string,
+  ) => {
+    setSelectedCategory((prev) => ({
+      ...prev,
+      [type]: value,
+    }));
+  };
+
+  const onSubmit = (data: { name: string }) => {
+    if (isCategoryEmpty) return;
+    console.log(data);
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className='flex w-fit flex-col gap-8'
+    >
+      <MealHeader
+        categories={categories}
+        month={month}
+        register={register}
+        errors={errors}
+        selectedCategory={selectedCategory}
+        handleCategoryChange={handleCategoryChange}
+        isValid={isValid}
+      />
+      <MealCalendar
+        selectedCategory={selectedCategory}
+        isValid={isValid}
+        year={year}
+        month={month}
+        readonly={true}
+        onDateClick={dataClick}
+      />
+    </form>
+  );
+};
+
+export default AutoPlan;

--- a/src/components/shared/Meal/MealCalender/index.tsx
+++ b/src/components/shared/Meal/MealCalender/index.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Calendar, { CalendarProps } from '@/components/common/Calendar';
+import { MealCalenderTitle } from '@/components/common/Typography';
+import MealHeaderButton from '@/components/shared/Meal/MealHeaderButton';
+
+type MealCalendarProps = {
+  type?: 'default' | 'create' | 'edit';
+  selectedCategory: {
+    organization: string | null;
+    organizationDetail: string | null;
+  };
+  isValid: boolean;
+} & CalendarProps;
+
+const MealCalendar = ({
+  type = 'default',
+  selectedCategory,
+  isValid,
+  year,
+  month,
+  data,
+  readonly,
+  onDateClick,
+}: MealCalendarProps) => {
+  const isCategoryEmpty =
+    !selectedCategory?.organization || !selectedCategory?.organizationDetail;
+
+  return (
+    <div className='flex w-fit flex-col gap-4'>
+      <div className='flex w-full justify-between'>
+        <MealCalenderTitle>{month}월</MealCalenderTitle>
+        {type === 'default' && (
+          <MealHeaderButton disabled={isCategoryEmpty || !isValid}>
+            생성
+          </MealHeaderButton>
+        )}
+        {type === 'create' && (
+          <div className='flex w-fit gap-2'>{/* 추후 추가 예정 */}</div>
+        )}
+      </div>
+      <Calendar
+        year={year}
+        month={month}
+        data={data}
+        readonly={readonly}
+        onDateClick={onDateClick}
+      />
+    </div>
+  );
+};
+
+export default MealCalendar;

--- a/src/components/shared/Meal/MealHeader/index.tsx
+++ b/src/components/shared/Meal/MealHeader/index.tsx
@@ -1,10 +1,27 @@
-import { useState } from 'react';
+'use client';
+
+import { FieldErrors, UseFormRegister } from 'react-hook-form';
+import { Input } from '@/components/common/Input';
 import { Option, Selectbox } from '@/components/common/Selectbox';
-import { MealHeaderTitle } from '@/components/common/Typography';
+
+type MealHeaderFormData = {
+  name: string;
+};
 
 type MealHeaderProps = {
-  name: string;
+  month: number;
   categories: Option[][];
+  register: UseFormRegister<MealHeaderFormData>;
+  errors: FieldErrors<MealHeaderFormData>;
+  selectedCategory: {
+    organization: string | null;
+    organizationDetail: string | null;
+  };
+  handleCategoryChange: (
+    type: 'organization' | 'organizationDetail',
+    value: string,
+  ) => void;
+  isValid: boolean;
 };
 
 export const organizationList = [
@@ -19,31 +36,60 @@ export const schoolLevelList = [
   { value: '고등학교', label: '고등학교' },
 ];
 
-const MealHeader = ({ name, categories }: MealHeaderProps) => {
-  const [organization, setOrganization] = useState<null | string>(null);
-
-  const onOrganizationChange = (organization: string) => {
-    setOrganization(organization);
-  };
+const MealHeader = ({
+  categories,
+  register,
+  errors,
+  selectedCategory,
+  handleCategoryChange,
+}: MealHeaderProps) => {
+  const isCategoryEmpty =
+    !selectedCategory.organization || !selectedCategory.organizationDetail;
 
   return (
-    <div className='flex w-full flex-col gap-8 px-14 py-10'>
-      <MealHeaderTitle>{name}</MealHeaderTitle>
-      <div className='flex gap-2'>
-        <Selectbox
-          options={organizationList}
-          size='basic'
-          onChange={(organization) => onOrganizationChange(organization)}
+    <div className='flex w-full flex-col gap-4'>
+      <div className='flex w-fit flex-col gap-2'>
+        <Input
+          bgcolor='search'
+          height='large'
+          placeholder='식단 이름을 입력하세요'
+          className='text-2xl font-semibold'
+          {...register('name')}
         />
-        {organizationList.map(
-          (item, index) =>
-            organization === item.value && (
-              <Selectbox
-                key={item.value}
-                options={categories[index]}
-                size='basic'
-              />
-            ),
+        {errors?.name?.message && (
+          <span className='text-red-300'>{errors.name.message.toString()}</span>
+        )}
+        <div className='flex gap-2'>
+          <Selectbox
+            options={organizationList}
+            size='basic'
+            onChange={(organization) =>
+              handleCategoryChange('organization', organization)
+            }
+            className={isCategoryEmpty ? 'border-red-300' : ''}
+          />
+          {organizationList.map(
+            (item, index) =>
+              selectedCategory.organization === item.value && (
+                <Selectbox
+                  key={item.value}
+                  options={categories[index]}
+                  size='basic'
+                  onChange={(organizationDetail) =>
+                    handleCategoryChange(
+                      'organizationDetail',
+                      organizationDetail,
+                    )
+                  }
+                  className={isCategoryEmpty ? 'border-red-300' : ''}
+                />
+              ),
+          )}
+        </div>
+        {isCategoryEmpty && (
+          <span className='mt-auto text-red-300'>
+            모든 카테고리를 선택해주세요
+          </span>
         )}
       </div>
     </div>

--- a/src/components/shared/Meal/MealHeaderButton/index.tsx
+++ b/src/components/shared/Meal/MealHeaderButton/index.tsx
@@ -1,0 +1,19 @@
+import { ComponentPropsWithoutRef } from 'react';
+import Button from '@/components/common/Button/Button';
+
+type MealHeaderButtonProps = {
+  disabled: boolean;
+} & ComponentPropsWithoutRef<'button'>;
+const MealHeaderButton = ({ disabled, ...props }: MealHeaderButtonProps) => {
+  return (
+    <Button
+      size='large'
+      className='h-10 w-fit'
+      disabled={disabled}
+      type='submit'
+      {...props}
+    />
+  );
+};
+
+export default MealHeaderButton;

--- a/src/constants/_schema.ts
+++ b/src/constants/_schema.ts
@@ -7,3 +7,10 @@ export const AUTH_ERROR = {
     name: '2~5자의 한글/영문만 사용 가능합니다',
   },
 };
+
+export const MEAL_HEADER_ERROR = {
+  name: {
+    min: '식단 이름은 최소 2자 이상 입력해주세요',
+    max: '식단 이름은 최대 20자까지 입력 가능합니다',
+  },
+};

--- a/src/schema/mealSchema.ts
+++ b/src/schema/mealSchema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+import { MEAL_HEADER_ERROR } from '@/constants/_schema';
+
+export const mealHeaderSchema = z.object({
+  name: z
+    .string()
+    .min(2, { message: MEAL_HEADER_ERROR.name.min })
+    .max(20, { message: MEAL_HEADER_ERROR.name.max }),
+});


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->
## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

-

### 설명 (선택)

- AutoPlan : 식단이름과 카테고리 선택해야만 생성 버튼 활성화
- 식단이름, 카테고리 선택하지 않을 시 에러메시지 
- MealCalendar : 현재 월과 각종 버튼 + 캘린더 

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
![image](https://github.com/user-attachments/assets/f40cc1e8-024e-4ae6-84cd-174fd3e871e9)

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- 먼저 수정되어야할 fix PR 부터 확인 부탁드립니다!
- 디코에 올려둔 input 스타일 수정 필요합니다
