### PR TITLE
Feat[#THKV-42]: 설문 조회 리스트 페이지 작성

### DIFF
--- a/src/app/(root)/viewChart/page.tsx
+++ b/src/app/(root)/viewChart/page.tsx
@@ -1,0 +1,7 @@
+import ViewChart from '@/components/feature/ViewChart';
+
+const page = () => {
+  return <ViewChart />;
+};
+
+export default page;

--- a/src/components/common/Typography/Typography.variant.tsx
+++ b/src/components/common/Typography/Typography.variant.tsx
@@ -24,6 +24,7 @@ export const typographyVariants = cva(
         question: 'text-[22px] leading-[145%]',
         mealHeaderTitle: 'text-[42px] leading-[150%]',
         authTitle: 'text-[50px] leading-[150%]',
+        pageHeaderTitle: 'text-[28px] leading-[145%]',
       },
       weight: {
         bold: 'font-bold',

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -47,3 +47,8 @@ export const MealHeaderTitle = customTypography('h1', {
   weight: 'bold',
   color: 'dark',
 });
+export const PageHeaderTitle = customTypography('h1', {
+  type: 'pageHeaderTitle',
+  weight: 'bold',
+  color: 'dark',
+});

--- a/src/components/feature/ViewChart/index.tsx
+++ b/src/components/feature/ViewChart/index.tsx
@@ -5,10 +5,10 @@ import Pagination from '@/components/common/Pagination';
 import GetAllListControls from '@/components/shared/GetAllList/Controls';
 import GetAllListHeader from '@/components/shared/GetAllList/Header';
 import GetAllListTable from '@/components/shared/GetAllList/ListTable';
-import { TAB_OPTIONS } from '@/constants/_controlTab';
-import { PLAN_DATA } from '@/constants/_getAllList/_planData';
+import { SURVEY_FILTER_OPTIONS, TAB_OPTIONS } from '@/constants/_controlTab';
+import { SURVEY_DATA } from '@/constants/_getAllList/_surveyData';
 
-const ViewPlan = () => {
+const ViewChart = () => {
   const [selectedYear, setSelectedYear] = useState<string>(
     new Date().getFullYear().toString(),
   );
@@ -16,7 +16,9 @@ const ViewPlan = () => {
     (new Date().getMonth() + 1).toString(),
   );
   const [searchValue, setSearchValue] = useState('');
-  const [organization, setOrganization] = useState<null | string>(null);
+  const [selectedFilter, setSelectedFilter] = useState<string>(
+    SURVEY_FILTER_OPTIONS[0],
+  );
   const [selectedTab, setSelectedTab] = useState<string>(TAB_OPTIONS[0]);
   const [page, setPage] = useState(1);
 
@@ -25,37 +27,45 @@ const ViewPlan = () => {
   };
 
   const submitSearchValue = () => {
-    // TODO: api request body로 보내줄 식단이름 제출함수
+    // TODO: api request body로 보내줄 설문이름 제출함수
     console.log('검색 버튼 클릭');
+  };
+
+  // 추후 react-query queryKey에 filter된 데이터 캐싱예정
+  const filterSurveys = (filterTab: string) => {
+    if (filterTab === '전체') {
+      return SURVEY_DATA;
+    }
+    return SURVEY_DATA.filter((survey) => survey.state === filterTab);
   };
 
   return (
     <div className='flex flex-col gap-4'>
-      <GetAllListHeader title={'내가 작성한 식단'} />
+      <GetAllListHeader title='설문 결과 리스트' />
       <GetAllListControls
-        type='viewPlan'
+        type='viewChart'
         selectedMonth={selectedMonth}
         selectedYear={selectedYear}
         onMonthChange={setSelectedMonth}
         onYearChange={setSelectedYear}
-        organization={organization}
-        setOrganization={setOrganization}
         searchValue={searchValue}
         handlechangeSearchValue={handlechangeSearchValue}
         submitSearchValue={submitSearchValue}
+        selectedFilter={selectedFilter}
+        setSelectedFilter={setSelectedFilter}
         selectedTab={selectedTab}
         setSelectedTab={setSelectedTab}
-        inputPlaceholder='식단 이름을 입력해주세요.'
+        inputPlaceholder='설문 이름을 입력해주세요.'
       />
-      <GetAllListTable data={PLAN_DATA} />
+      <GetAllListTable data={filterSurveys(selectedFilter)} />
       <Pagination
         limit={8}
         page={page}
         setPage={setPage}
-        totalPosts={PLAN_DATA.length}
+        totalPosts={SURVEY_DATA.length}
       />
     </div>
   );
 };
 
-export default ViewPlan;
+export default ViewChart;

--- a/src/components/shared/GetAllList/Controls/index.tsx
+++ b/src/components/shared/GetAllList/Controls/index.tsx
@@ -1,10 +1,11 @@
 'use client';
 
+import { cn } from '@/utils/core';
 import ControlTab from '@/components/common/ControlTab';
 import DatePicker from '@/components/common/DatePicker';
 import { Input } from '@/components/common/Input';
 import { Selectbox } from '@/components/common/Selectbox';
-import { TAB_OPTIONS } from '@/constants/_controlTab';
+import { SURVEY_FILTER_OPTIONS, TAB_OPTIONS } from '@/constants/_controlTab';
 import { CATEGORIES, ORGANIZATIONS } from '@/constants/_getAllList/_categories';
 
 interface Props {
@@ -18,11 +19,15 @@ interface Props {
   searchValue: string;
   handlechangeSearchValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
   submitSearchValue: () => void;
+  selectedFilter?: string;
+  setSelectedFilter?: React.Dispatch<React.SetStateAction<string>>;
   selectedTab: string;
   setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
+  inputPlaceholder: string;
 }
 
 const GetAllListControls = ({
+  type,
   selectedMonth,
   selectedYear,
   onMonthChange,
@@ -32,8 +37,11 @@ const GetAllListControls = ({
   searchValue,
   handlechangeSearchValue,
   submitSearchValue,
+  selectedFilter,
+  setSelectedFilter,
   selectedTab,
   setSelectedTab,
+  inputPlaceholder,
 }: Props) => {
   return (
     <>
@@ -44,37 +52,54 @@ const GetAllListControls = ({
           onMonthChange={onMonthChange}
           onYearChange={onYearChange}
         />
-        <div className='flex w-full justify-end gap-5'>
+        <div
+          className={cn(
+            'flex w-full items-end justify-end gap-5',
+            type === 'viewChart' && 'w-1/2',
+          )}
+        >
           <Input
             isLeftIcon={true}
             height='basic'
-            placeholder='식단 이름을 입력해주세요.'
+            placeholder={inputPlaceholder}
             bgcolor='search'
             includeButton={true}
             value={searchValue}
             onChange={handlechangeSearchValue}
             onSubmit={submitSearchValue}
           />
-          <div className='flex whitespace-pre'>
-            <Selectbox
-              options={ORGANIZATIONS}
-              size='small'
-              onChange={(organization) => setOrganization!(organization)}
-            />
-            {ORGANIZATIONS.map(
-              (item, index) =>
-                organization === item.value && (
-                  <Selectbox
-                    key={item.value}
-                    options={CATEGORIES[index]}
-                    size='small'
-                  />
-                ),
-            )}
-          </div>
+          {type === 'viewPlan' && (
+            <div className='flex gap-1 whitespace-pre'>
+              <Selectbox
+                options={ORGANIZATIONS}
+                size='small'
+                onChange={(organization) => setOrganization!(organization)}
+              />
+              {ORGANIZATIONS.map(
+                (item, index) =>
+                  organization === item.value && (
+                    <Selectbox
+                      key={item.value}
+                      options={CATEGORIES[index]}
+                      size='small'
+                    />
+                  ),
+              )}
+            </div>
+          )}
         </div>
       </div>
-      <div className='flex justify-end'>
+      <div className='flex items-center justify-end gap-3'>
+        {type === 'viewChart' && (
+          <>
+            <ControlTab
+              controlTabItems={SURVEY_FILTER_OPTIONS}
+              selectedTab={selectedFilter!}
+              setSelectedTab={setSelectedFilter!}
+            />
+            <span className='mx-1 cursor-default text-gray-500'>|</span>
+          </>
+        )}
         <ControlTab
           controlTabItems={TAB_OPTIONS}
           selectedTab={selectedTab}

--- a/src/components/shared/GetAllList/Header/index.tsx
+++ b/src/components/shared/GetAllList/Header/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MealHeaderTitle } from '@/components/common/Typography';
+import { PageHeaderTitle } from '@/components/common/Typography';
 
 interface Props {
   title: string;
@@ -9,7 +9,7 @@ interface Props {
 const ViewPlanHeader = ({ title }: Props) => {
   return (
     <>
-      <MealHeaderTitle>{title}</MealHeaderTitle>
+      <PageHeaderTitle>{title}</PageHeaderTitle>
     </>
   );
 };

--- a/src/constants/_controlTab.ts
+++ b/src/constants/_controlTab.ts
@@ -1,1 +1,2 @@
 export const TAB_OPTIONS = ['최신순', '오래된 순'];
+export const SURVEY_FILTER_OPTIONS = ['전체', '진행중', '마감'];

--- a/src/constants/_getAllList/_surveyData.ts
+++ b/src/constants/_getAllList/_surveyData.ts
@@ -1,0 +1,50 @@
+export const SURVEY_DATA = [
+  {
+    id: 1,
+    title: '설문이름1',
+    createdAt: '2024.09.14',
+    state: '진행중',
+  },
+  {
+    id: 2,
+    title: '설문이름2',
+    createdAt: '2024.09.14',
+    state: '진행중',
+  },
+  {
+    id: 3,
+    title: '설문이름3',
+    createdAt: '2024.09.14',
+    state: '마감',
+  },
+  {
+    id: 4,
+    title: '설문이름4',
+    createdAt: '2024.09.14',
+    state: '마감',
+  },
+  {
+    id: 5,
+    title: '설문이름5',
+    createdAt: '2024.09.14',
+    state: '마감',
+  },
+  {
+    id: 6,
+    title: '설문이름6',
+    createdAt: '2024.09.14',
+    state: '진행중',
+  },
+  {
+    id: 7,
+    title: '설문이름7',
+    createdAt: '2024.09.14',
+    state: '마감',
+  },
+  {
+    id: 8,
+    title: '설문이름8',
+    createdAt: '2024.09.14',
+    state: '진행중',
+  },
+];


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 식단 조회 리스트에서 사용한 컴포넌트들 재사용하여 설문 조회 리스트 페이지 구현

### 설명 (선택)

- 설문 조회 리스트에는 Selectbox 제거
- 설문 조회 리스트에는 진행중 / 마감 필터 Tab 추가

## 스크린샷

<img width="1188" alt="스크린샷 2024-09-17 오후 11 59 45" src="https://github.com/user-attachments/assets/5d3bfd40-4c68-4ad8-9b21-3bf5ab194c8a">

## 리뷰 요구사항

- 필터링을 어떻게 보여줘야할지 찾아봤는데 Tab사용이 제일 많은거 같아 사용해보았습니다
다른 좋은 방법 생각나시면 언제든 말씀주세영
- api명세서에 수정이 안된건지 전달이 안된건진 확인해봐야겠지만
response에 생성일자는 있지만, 마감일자는 없어서 생성일자만 일단 넣었습니다!
