### PR TITLE
Refactor[#THKV-49] : 자동식단 페이지 수정사항 반영

### DIFF
--- a/src/components/common/Calendar/index.tsx
+++ b/src/components/common/Calendar/index.tsx
@@ -67,7 +67,7 @@ const Calendar = ({
           </div>
         ))}
       </div>
-      <div className='w-160 grid grid-cols-7 overflow-hidden border-[0.5px] border-gray-200'>
+      <div className='custom-scrollbar w-160 grid h-[690px] grid-cols-7 overflow-y-scroll border-[0.5px] border-gray-200'>
         {allDays.map((date, index) => {
           const formattedDate = date.format('YYYY-MM-DD');
           const isActive = formattedDate === activeDate;

--- a/src/components/common/Icon/assets/index.ts
+++ b/src/components/common/Icon/assets/index.ts
@@ -71,7 +71,7 @@ export const iconMap: Record<string, IconMapEntry> = {
     type: 'stroke',
     file: Normal,
   },
-  dander: {
+  danger: {
     type: 'stroke',
     file: Danger,
   },

--- a/src/components/common/InfoCard/index.tsx
+++ b/src/components/common/InfoCard/index.tsx
@@ -1,0 +1,22 @@
+import { cn } from '@/utils/core';
+import Icon from '@/components/common/Icon';
+
+type InfoCardProps = {
+  message: string;
+  className?: string;
+};
+const InfoCard = ({ message, className }: InfoCardProps) => {
+  return (
+    <div
+      className={cn(
+        'w-88 flex h-fit items-center gap-2 rounded-md border-[1px] border-green-300 bg-white-100 p-4',
+        className,
+      )}
+    >
+      <Icon name='normal' />
+      <span className='font-medium'>{message}</span>
+    </div>
+  );
+};
+
+export default InfoCard;

--- a/src/components/common/SelectButton/SelectButton.variant.tsx
+++ b/src/components/common/SelectButton/SelectButton.variant.tsx
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const selectButtonVariants = cva(
-  'w-fit border-[1px] border-gray-300 rounded-md bg-white-100 text-left focus:border-green-700 focus:outline-none',
+  'w-fit border-[1px] border-gray-300 rounded-md bg-white-100 text-left text-nowrap focus:border-green-700 focus:outline-none',
   {
     variants: {
       size: {

--- a/src/components/feature/AutoPlan/index.tsx
+++ b/src/components/feature/AutoPlan/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useForm } from 'react-hook-form';
 import { mealHeaderSchema } from '@/schema/mealSchema';
+import InfoCard from '@/components/common/InfoCard';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
 import MealHeader from '@/components/shared/Meal/MealHeader';
 import { MOCK_CATEGORY_LIST } from '@/constants/_category';
@@ -50,26 +51,32 @@ const AutoPlan = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <fieldset className='flex w-fit flex-col gap-8'>
-        <legend className='sr-only'>자동 식단 이름 및 카테고리 등록</legend>
-        <MealHeader
-          categories={MOCK_CATEGORY_LIST}
-          register={register}
-          errors={errors}
-          selectedCategory={selectedCategory}
-          handleCategoryChange={handleCategoryChange}
-          isValid={isValid}
-        />
-        <MealCalendar
-          selectedCategory={selectedCategory}
-          isValid={isValid}
-          year={year}
-          month={month}
-          readonly={true}
-        />
-      </fieldset>
-    </form>
+    <div className='relative'>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <fieldset className='flex w-fit flex-col gap-4'>
+          <legend className='sr-only'>자동 식단 이름 및 카테고리 등록</legend>
+          <MealHeader
+            categories={MOCK_CATEGORY_LIST}
+            register={register}
+            errors={errors}
+            selectedCategory={selectedCategory}
+            handleCategoryChange={handleCategoryChange}
+            isValid={isValid}
+          />
+          <MealCalendar
+            selectedCategory={selectedCategory}
+            isValid={isValid}
+            year={year}
+            month={month}
+            readonly={true}
+          />
+        </fieldset>
+      </form>
+      <div className='absolute right-2 top-1/4 flex flex-col gap-2'>
+        <InfoCard message='선택한 카테고리에 맞는 식단이 자동으로 생성됩니다.' />
+        <InfoCard message='식단을 원하는 이름으로 생성하고, 관리할 수 있습니다.' />
+      </div>
+    </div>
   );
 };
 

--- a/src/components/feature/AutoPlan/index.tsx
+++ b/src/components/feature/AutoPlan/index.tsx
@@ -51,7 +51,7 @@ const AutoPlan = () => {
   };
 
   return (
-    <div className='relative'>
+    <div className='flex gap-8'>
       <form onSubmit={handleSubmit(onSubmit)}>
         <fieldset className='flex w-fit flex-col gap-4'>
           <legend className='sr-only'>자동 식단 이름 및 카테고리 등록</legend>
@@ -72,7 +72,7 @@ const AutoPlan = () => {
           />
         </fieldset>
       </form>
-      <div className='absolute right-2 top-1/4 flex flex-col gap-2'>
+      <div className='flex flex-col gap-2 pt-[166px]'>
         <InfoCard message='선택한 카테고리에 맞는 식단이 자동으로 생성됩니다.' />
         <InfoCard message='식단을 원하는 이름으로 생성하고, 관리할 수 있습니다.' />
       </div>

--- a/src/components/feature/AutoPlanCreate/index.tsx
+++ b/src/components/feature/AutoPlanCreate/index.tsx
@@ -27,7 +27,7 @@ const AutoPlanCreate = () => {
 
   return (
     <form onSubmit={handleSubmit}>
-      <fieldset className='flex w-fit flex-col gap-8'>
+      <fieldset className='flex w-fit flex-col gap-4'>
         <legend className='sr-only'>자동 식단 이름 및 카테고리 등록</legend>
         <MealCreateHeader
           inputValue={mealName}

--- a/src/components/feature/AutoPlanEdit/index.tsx
+++ b/src/components/feature/AutoPlanEdit/index.tsx
@@ -15,7 +15,7 @@ const AutoPlanEdit = () => {
   // api로부터 전달 받는 값
   const mealName = '맛있는 9월 식단 야호';
   const category = {
-    organization: '초등학교',
+    organization: '학교명',
     organizationDetail: '냠냠초등학교',
   };
   const [totalMenuList, setTotalMenuList] = useState(MOCK_CALENDAR_NUTRITION);
@@ -75,7 +75,7 @@ const AutoPlanEdit = () => {
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
-      <fieldset className='flex w-fit flex-col gap-8'>
+      <fieldset className='flex w-fit flex-col gap-4'>
         <legend className='sr-only'>자동 식단 이름 및 카테고리 수정</legend>
         <MealHeader
           categories={MOCK_CATEGORY_LIST}

--- a/src/components/shared/Meal/MealCalender/index.tsx
+++ b/src/components/shared/Meal/MealCalender/index.tsx
@@ -56,7 +56,7 @@ const MealCalendar = ({
             </Button>
           )}
           {type === 'create' && (
-            <div className='flex w-fit gap-2'>
+            <div className='flex w-fit items-center gap-2'>
               <Button className='h-10 w-fit' size='large' type='submit'>
                 저장
               </Button>
@@ -66,7 +66,7 @@ const MealCalendar = ({
             </div>
           )}
           {type === 'edit' && (
-            <div className='flex w-fit gap-2'>
+            <div className='flex w-fit items-center gap-2'>
               <Button className='h-10 w-fit' size='large' type='submit'>
                 수정 완료
               </Button>

--- a/src/components/shared/Meal/MealCalender/index.tsx
+++ b/src/components/shared/Meal/MealCalender/index.tsx
@@ -42,8 +42,8 @@ const MealCalendar = ({
 
   return (
     <div className='flex gap-8'>
-      <div className='flex w-fit flex-col gap-4'>
-        <div className='flex w-full justify-between'>
+      <div className='flex w-fit flex-col gap-2'>
+        <div className='flex w-full items-center justify-between'>
           <MealCalenderTitle>{month}월</MealCalenderTitle>
           {type === 'default' && (
             <Button

--- a/src/components/shared/Meal/MealCreateHeader/index.tsx
+++ b/src/components/shared/Meal/MealCreateHeader/index.tsx
@@ -11,9 +11,9 @@ const MealCreateHeader = ({
   seletedCategory,
 }: MealCreateHeaderProps) => {
   return (
-    <div className='flex w-fit flex-col gap-4'>
+    <div className='flex w-fit items-center gap-4'>
       <Input
-        className='text-2xl font-semibold'
+        className='text-2xl font-semibold focus:border-green-400'
         bgcolor='meal'
         height='large'
         value={inputValue}
@@ -22,11 +22,13 @@ const MealCreateHeader = ({
         <Selectbox
           size='basic'
           selectedValue={seletedCategory[0]}
+          className='cursor-not-allowed focus:border-gray-300'
           readonly={true}
         />
         <Selectbox
           size='basic'
           selectedValue={seletedCategory[1]}
+          className='cursor-not-allowed focus:border-gray-300'
           readonly={true}
         />
       </div>

--- a/src/components/shared/Meal/MealEdit/index.tsx
+++ b/src/components/shared/Meal/MealEdit/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Icon from '@/components/common/Icon';
 import { Input } from '@/components/common/Input';
 import { NutritionMenu } from '@/components/common/Typography';
@@ -32,22 +32,19 @@ const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
     setClickedMenu(menu);
   };
 
-  const handleClickNewMenu = useCallback(
-    (menu: string) => {
-      const result = MOCK_ALL_MENU.find((item) => item.content === menu);
+  const handleClickNewMenu = (menu: string) => {
+    const result = MOCK_ALL_MENU.find((item) => item.content === menu);
 
-      if (result && handleChangeMenu) {
-        const menuName =
-          data.find((item) => item.content === clickedMenu)?.content || '';
-        handleChangeMenu(date, menuName, result);
+    if (result && handleChangeMenu) {
+      const menuName =
+        data.find((item) => item.content === clickedMenu)?.content || '';
+      handleChangeMenu(date, menuName, result);
 
-        setClickedMenu(menu);
-        setKeyword(menu);
-        setIsSearchShow(false);
-      }
-    },
-    [date, data, clickedMenu, handleChangeMenu],
-  );
+      setClickedMenu(menu);
+      setKeyword(menu);
+      setIsSearchShow(false);
+    }
+  };
 
   useEffect(() => {
     setClickedMenu('');

--- a/src/components/shared/Meal/MealEdit/index.tsx
+++ b/src/components/shared/Meal/MealEdit/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import Icon from '@/components/common/Icon';
 import { Input } from '@/components/common/Input';
 import { NutritionMenu } from '@/components/common/Typography';
@@ -20,7 +20,7 @@ type MealEditProps = {
 
 const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
   const [clickedMenu, setClickedMenu] = useState('');
-  const [keyword, setKeyword] = useState('');
+  const [keyword, setKeyword] = useState<string | null>(null);
   const [isSearchShow, setIsSearchShow] = useState(false);
   const [searchResult, setSearchResult] = useState<NutritionData[]>([]);
 
@@ -39,23 +39,32 @@ const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
     [],
   );
 
-  const handleClickNewMenu = (menu: string) => {
-    const result = MOCK_ALL_MENU.find((item) => item.content === menu);
+  const handleClickNewMenu = useCallback(
+    (menu: string) => {
+      const result = MOCK_ALL_MENU.find((item) => item.content === menu);
 
-    if (result && handleChangeMenu) {
-      const menuName =
-        data.find((item) => item.content === clickedMenu)?.content || '';
-      handleChangeMenu(date, menuName, result);
-    }
-  };
+      if (result && handleChangeMenu) {
+        const menuName =
+          data.find((item) => item.content === clickedMenu)?.content || '';
+        handleChangeMenu(date, menuName, result);
+
+        setClickedMenu(menu);
+        setKeyword(menu);
+        setIsSearchShow(false);
+      }
+    },
+    [date, data, clickedMenu, handleChangeMenu],
+  );
 
   useEffect(() => {
+    if (!keyword) return;
     handleChangeKeyword(MOCK_ALL_MENU, keyword);
   }, [keyword, handleChangeKeyword]);
 
   useEffect(() => {
     setClickedMenu('');
     setKeyword('');
+    setIsSearchShow(false);
   }, [date]);
 
   if (!data) return null;
@@ -79,31 +88,31 @@ const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
         <KcalInfo data={data} />
       </div>
       <div className='flex w-full flex-col gap-2'>
-        {isSearchShow && (
-          <Input
-            className='text-md placeholder:text-md font-semibold'
-            placeholder='메뉴 이름을 입력해주세요'
-            bgcolor='search'
-            onChange={(e) => setKeyword(e.target.value)}
-            value={keyword || ''}
-          />
-        )}
-        {keyword && (
-          <div className='custom-scrollbar max-h-[500px] w-full overflow-y-auto rounded-md bg-white-200 p-2'>
-            {searchResult.length === 0 ? (
-              <NutritionMenu>메뉴가 존재하지 않습니다</NutritionMenu>
-            ) : (
-              <MealTable
-                data={searchResult}
-                isButton
-                onClick={handleClickNewMenu}
-              />
-            )}
-          </div>
+        {isSearchShow && keyword!.length >= 0 && (
+          <>
+            <Input
+              className='text-md placeholder:text-md font-semibold'
+              placeholder='메뉴 이름을 입력해주세요'
+              bgcolor='search'
+              onChange={(e) => setKeyword(e.target.value)}
+              value={keyword || ''}
+            />
+            <div className='custom-scrollbar max-h-[500px] w-full overflow-y-auto rounded-md bg-white-200 p-2'>
+              {searchResult.length === 0 ? (
+                <NutritionMenu>메뉴가 존재하지 않습니다</NutritionMenu>
+              ) : (
+                <MealTable
+                  data={searchResult}
+                  isButton
+                  onClick={handleClickNewMenu}
+                />
+              )}
+            </div>
+          </>
         )}
       </div>
     </MealInfoContainer>
   );
 };
 
-export default MealEdit;
+export default memo(MealEdit);

--- a/src/components/shared/Meal/MealEdit/index.tsx
+++ b/src/components/shared/Meal/MealEdit/index.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Icon from '@/components/common/Icon';
 import { Input } from '@/components/common/Input';
 import { NutritionMenu } from '@/components/common/Typography';
@@ -20,24 +20,17 @@ type MealEditProps = {
 
 const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
   const [clickedMenu, setClickedMenu] = useState('');
-  const [keyword, setKeyword] = useState<string | null>(null);
+  const [keyword, setKeyword] = useState('');
   const [isSearchShow, setIsSearchShow] = useState(false);
-  const [searchResult, setSearchResult] = useState<NutritionData[]>([]);
+
+  const searchResult = useMemo(() => {
+    return MOCK_ALL_MENU.filter((item) => item.content.includes(keyword));
+  }, [keyword]);
 
   const handleClickMenu = (menu: string) => {
     setKeyword(menu);
     setClickedMenu(menu);
   };
-
-  const handleChangeKeyword = useCallback(
-    (allMenuData: NutritionData[], keyword: string) => {
-      const result = allMenuData.filter((item) =>
-        item.content.includes(keyword),
-      );
-      setSearchResult(result);
-    },
-    [],
-  );
 
   const handleClickNewMenu = useCallback(
     (menu: string) => {
@@ -55,11 +48,6 @@ const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
     },
     [date, data, clickedMenu, handleChangeMenu],
   );
-
-  useEffect(() => {
-    if (!keyword) return;
-    handleChangeKeyword(MOCK_ALL_MENU, keyword);
-  }, [keyword, handleChangeKeyword]);
 
   useEffect(() => {
     setClickedMenu('');
@@ -115,4 +103,4 @@ const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
   );
 };
 
-export default memo(MealEdit);
+export default MealEdit;

--- a/src/components/shared/Meal/MealHeader/index.tsx
+++ b/src/components/shared/Meal/MealHeader/index.tsx
@@ -37,8 +37,8 @@ const MealHeader = ({
     !selectedCategory.organization || !selectedCategory.organizationDetail;
 
   return (
-    <div className='flex w-full flex-col gap-4'>
-      <div className='flex w-fit flex-col gap-2'>
+    <div className='flex w-full items-center gap-4'>
+      <div className='relative flex h-fit flex-col'>
         <Input
           bgcolor='meal'
           height='large'
@@ -47,37 +47,38 @@ const MealHeader = ({
           {...register('name')}
         />
         {errors?.name?.message && (
-          <span className='text-red-300'>{errors.name.message.toString()}</span>
+          <span className='absolute bottom-[-26px] text-nowrap text-red-300'>
+            {errors.name.message.toString()}
+          </span>
         )}
-        <div className='flex gap-2'>
-          <Selectbox
-            options={ORGANIZATION_LIST}
-            size='basic'
-            onChange={(organization) =>
-              handleCategoryChange('organization', organization)
-            }
-            className={isCategoryEmpty ? 'border-red-300' : ''}
-          />
-          {ORGANIZATION_LIST.map(
-            (item, index) =>
-              selectedCategory.organization === item.value && (
-                <Selectbox
-                  key={item.value}
-                  options={categories[index]}
-                  size='basic'
-                  onChange={(organizationDetail) =>
-                    handleCategoryChange(
-                      'organizationDetail',
-                      organizationDetail,
-                    )
-                  }
-                  className={isCategoryEmpty ? 'border-red-300' : ''}
-                />
-              ),
-          )}
-        </div>
+      </div>
+      <div className='relative flex gap-2'>
+        <Selectbox
+          options={ORGANIZATION_LIST}
+          size='basic'
+          onChange={(organization) =>
+            handleCategoryChange('organization', organization)
+          }
+          className={isCategoryEmpty ? 'border-red-300' : ''}
+        />
+        {ORGANIZATION_LIST.map(
+          (item, index) =>
+            selectedCategory.organization === item.value && (
+              <Selectbox
+                key={item.value}
+                options={categories[index]}
+                size='basic'
+                onChange={(organizationDetail) =>
+                  handleCategoryChange('organizationDetail', organizationDetail)
+                }
+                className={isCategoryEmpty ? 'border-red-300' : ''}
+              />
+            ),
+        )}
         {isCategoryEmpty && (
-          <span className='mt-auto text-red-300'>{categoryErrorMsg}</span>
+          <span className='absolute bottom-[-32px] mt-auto text-nowrap text-red-300'>
+            {categoryErrorMsg}
+          </span>
         )}
       </div>
     </div>

--- a/src/components/shared/Meal/MealHeader/index.tsx
+++ b/src/components/shared/Meal/MealHeader/index.tsx
@@ -15,8 +15,8 @@ type MealHeaderProps = {
   errors: FieldErrors<MealHeaderFormData>;
   categoryErrorMsg?: string;
   selectedCategory: {
-    organization: string | null;
-    organizationDetail: string | null;
+    organization: string;
+    organizationDetail: string;
   };
   handleCategoryChange: (
     type: 'organization' | 'organizationDetail',
@@ -60,6 +60,7 @@ const MealHeader = ({
             handleCategoryChange('organization', organization)
           }
           className={isCategoryEmpty ? 'border-red-300' : ''}
+          selectedValue={selectedCategory.organization}
         />
         {ORGANIZATION_LIST.map(
           (item, index) =>
@@ -72,6 +73,7 @@ const MealHeader = ({
                   handleCategoryChange('organizationDetail', organizationDetail)
                 }
                 className={isCategoryEmpty ? 'border-red-300' : ''}
+                selectedValue={selectedCategory.organizationDetail}
               />
             ),
         )}

--- a/src/components/shared/Meal/MealInfoContainer/index.tsx
+++ b/src/components/shared/Meal/MealInfoContainer/index.tsx
@@ -7,7 +7,7 @@ type MealInfoContainerProps = {
 
 const MealInfoContainer = ({ children, date }: MealInfoContainerProps) => {
   return (
-    <div className='flex h-fit w-80 flex-col gap-1 rounded-md border-[1px] border-green-400 bg-white-100 p-4'>
+    <div className='fixed top-[10px] flex h-fit w-80 flex-col gap-1 rounded-md border-[1px] border-green-400 bg-white-100 p-4'>
       <div className='text-center'>
         <NutritionDate>{date}</NutritionDate>
       </div>

--- a/src/components/shared/Meal/MealTable/index.tsx
+++ b/src/components/shared/Meal/MealTable/index.tsx
@@ -11,7 +11,7 @@ type MealTableProps = {
 
 const MealTable = ({ data, isButton = false, onClick }: MealTableProps) => {
   return (
-    <div className='flex w-full flex-col gap-2'>
+    <div className='flex w-full flex-col'>
       {data?.map((item) => {
         const tableData = [
           {


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 자동 식단 생성 기본, 자동 식단 생성 추가, 자동 식단 생성 수정 페이지 수정사항 반영하였습니다.
- TableHeader, Navbar, Button 변경 사항들은 오늘 회의 전까지 따로 PR 올리겠습니다.

### 설명 (선택)

#### 자동 식단 생성 기본(/)
- 선택한 카테고리 기준으로 식단이 자동 생성된다는 걸 유저도 알 수 있도록 InfoCard 컴포넌트 구현 및 적용

#### 자동 식단 생성 추가(/create)
- 식단이름, 카테고리 클릭 못하게 금지 커서로 변경
- 영양정보, 메뉴정보 컨테이너 position fixed 로 변경
- 식단 이름 input 옆에 옵션 카테고리 오도록 direction 수정 및 에러메시지 absolute 적용
- 캘린더 테이블 바디에만 y-scroll 넣기

#### 자동 식단 생성 수정(/edit)
- 카테고리 기본으로 들어가있게 수정
- 메뉴 변경 시 두 번 눌러야 반영됨
- 다른 날짜로 누르면 검색바 보이지 않게
- 메뉴 수정 시 검색바 + 검색 목록 없애기

#### 기타
- flex 갭 너무 큰 컴포넌트들 수정
- 오타 수정
- 자세한 내용은 커밋 메시지 확인하시면 됩니다!

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
#### 자동 식단 생성 기본(/)
![image](https://github.com/user-attachments/assets/166b3614-5d06-4845-9e25-1d7ccf091a7a)

#### 자동 식단 생성 추가 (/create)
![image](https://github.com/user-attachments/assets/5b3ac9be-ec3a-4b18-a109-c6190480285e)

#### 자동 식단 생성 수정 (/edit)
![image](https://github.com/user-attachments/assets/db468197-6324-409b-ad58-50661126f9a0)

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
- 캘린더 바디에 스크롤을 넣으니까 grid가 적용되서 이상한 박스가 하나 생겼습니다.. 이 부분 추가로 수정해야할 것 같습니다.
- 메뉴 수정 폼의 취소, 수정 적용 버튼 관련하여 팀채널에 메시지 남겼으니 확인해주시면 감사하겠습니다.