### PR TITLE
Feat[#THKV-44] : 수동 식단 작성 페이지(/menualPlan) 구현

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,1 @@
-# .husky/pre-push
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npm run build

--- a/src/app/(root)/menualPlan/page.tsx
+++ b/src/app/(root)/menualPlan/page.tsx
@@ -1,0 +1,7 @@
+import MenualPlan from '@/components/feature/MenualPlan';
+
+const page = () => {
+  return <MenualPlan />;
+};
+
+export default page;

--- a/src/components/common/Calendar/Calendar.variant.tsx
+++ b/src/components/common/Calendar/Calendar.variant.tsx
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const calendarDayVariants = cva(
-  'w-40 h-44 pt-1 pr-2 pb-2 pl-2 flex flex-col text-left bg-white-100 border-[0.5px] border-gray-200 hover:border-gray-400 active:border-gray-500',
+  'w-full h-44 pt-1 pr-2 pb-2 pl-2 flex flex-col text-left bg-white-100 border-[0.5px] border-gray-200 hover:border-gray-400 active:border-gray-500',
   {
     variants: {
       isInvalid: {

--- a/src/components/common/Calendar/index.tsx
+++ b/src/components/common/Calendar/index.tsx
@@ -67,7 +67,7 @@ const Calendar = ({
           </span>
         ))}
       </div>
-      <div className='scrollbar-gray-100 h-[690px] w-full overflow-x-hidden overflow-y-scroll'>
+      <div className='scrollbar-gray-100 h-[690px] w-full overflow-x-hidden overflow-y-scroll md:w-[700px] lg:w-[1244px]'>
         <div className='grid grid-cols-7 border-[0.5px] border-gray-200'>
           {allDays.map((date, index) => {
             const formattedDate = date.format('YYYY-MM-DD');

--- a/src/components/common/CalendarDay/index.tsx
+++ b/src/components/common/CalendarDay/index.tsx
@@ -11,7 +11,7 @@ export type CalendarDayProps = {
   onClick: () => void;
 };
 
-const MAXIUM_MENU_PER_DAY = 7;
+export const MAXIUM_MENU_PER_DAY = 7;
 
 const CalendarDay = ({
   date,

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -27,8 +27,8 @@ const Table = ({
   );
 
   return (
-    <div className='w-full overflow-hidden rounded-md'>
-      <table className='w-full border-collapse text-center'>
+    <div className='w-full'>
+      <table className='w-full border-separate border-spacing-0 overflow-hidden rounded-lg text-center'>
         <TableHeader headerData={tableHeaders} className={headerClassName} />
         <TableBody
           headerData={tableHeaders}

--- a/src/components/common/TableBody/index.tsx
+++ b/src/components/common/TableBody/index.tsx
@@ -6,6 +6,7 @@ type TableBodyProps = {
   bodyData: TableRowData[];
   type: TableType;
   className?: string;
+  onClick?: () => void;
 };
 
 const TableBody = ({
@@ -13,22 +14,41 @@ const TableBody = ({
   bodyData,
   type,
   className,
+  onClick,
 }: TableBodyProps) => {
-  const handleTrClick = () => {};
-
   return (
-    <tbody>
-      {bodyData.map((item, index) => (
+    <tbody className='bg-white-100'>
+      {bodyData.map((item, rowIndex) => (
         <tr
-          key={index}
-          className='border-thead border-y'
-          onClick={type === 'list' ? handleTrClick : undefined}
+          key={rowIndex}
+          className='border-separate border-spacing-0 cursor-pointer'
+          onClick={type === 'list' ? onClick : undefined}
         >
-          {headerData.map((header) => (
-            <td key={header} className={cn('bg-white-100 p-3', className)}>
-              {item[header] !== undefined ? item[header] : '-'}
-            </td>
-          ))}
+          {headerData.map((header, colIndex) => {
+            const isFirst = colIndex === 0;
+            const isLast = colIndex === headerData.length - 1;
+            const isLastRow = rowIndex === bodyData.length - 1;
+
+            const additionalClasses = cn({
+              'border-l': isFirst,
+              'border-r': isLast,
+              'rounded-bl-lg border-l border-b': isFirst && isLastRow,
+              'rounded-br-lg border-r border-b': isLast && isLastRow,
+            });
+
+            return (
+              <td
+                key={header}
+                className={cn(
+                  'border-b border-gray-400 p-3',
+                  additionalClasses,
+                  className,
+                )}
+              >
+                {item[header] !== undefined ? item[header] : '-'}
+              </td>
+            );
+          })}
         </tr>
       ))}
     </tbody>

--- a/src/components/common/TableHeader/index.tsx
+++ b/src/components/common/TableHeader/index.tsx
@@ -7,19 +7,30 @@ type TableHeaderProps = {
 
 const TableHeader = ({ headerData, className }: TableHeaderProps) => {
   return (
-    <thead>
-      <tr>
-        {headerData.map((header) => (
-          <th
-            key={header}
-            className={cn(
-              'border-thead border-[1px] border-green-400 bg-green-100 p-3 font-semibold',
-              className,
-            )}
-          >
-            {header}
-          </th>
-        ))}
+    <thead className='bg-green-100'>
+      <tr className='border-separate border-spacing-0'>
+        {headerData.map((header, index) => {
+          const isFirst = index === 0;
+          const isLast = index === headerData.length - 1;
+
+          const additionalClasses = cn({
+            'rounded-tl-lg border-l': isFirst,
+            'rounded-tr-lg border-r': isLast,
+          });
+
+          return (
+            <th
+              key={header}
+              className={cn(
+                'border-b border-t border-green-400 p-3 font-semibold',
+                additionalClasses,
+                className,
+              )}
+            >
+              {header}
+            </th>
+          );
+        })}
       </tr>
     </thead>
   );

--- a/src/components/common/Tooltip/Tooltip.variant.tsx
+++ b/src/components/common/Tooltip/Tooltip.variant.tsx
@@ -1,0 +1,15 @@
+import { cva } from 'class-variance-authority';
+
+export const tooltipVariants = cva(
+  'absolute z-10 w-40 rounded-lg bg-white-100 border border-gray-200 px-3 py-2 text-sm shadow-md break-all',
+  {
+    variants: {
+      position: {
+        top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+        right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+        bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+        left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+      },
+    },
+  },
+);

--- a/src/components/common/Tooltip/index.tsx
+++ b/src/components/common/Tooltip/index.tsx
@@ -1,0 +1,38 @@
+import { useState, ReactNode } from 'react';
+import { VariantProps } from 'class-variance-authority';
+import { tooltipVariants } from '@/components/common/Tooltip/Tooltip.variant';
+
+export type TooltipVariant = VariantProps<typeof tooltipVariants>['position'];
+
+type TooltipProps = {
+  children: ReactNode;
+  content: string;
+  position?: 'top' | 'right' | 'bottom' | 'left';
+};
+
+const Tooltip = ({ children, content, position = 'top' }: TooltipProps) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  return (
+    <div className='relative inline-block'>
+      <div
+        onMouseEnter={() => setIsVisible(true)}
+        onMouseLeave={() => setIsVisible(false)}
+      >
+        {children}
+      </div>
+      {isVisible && (
+        <div
+          className={tooltipVariants({ position })}
+          role='tooltip'
+          aria-hidden={!isVisible}
+        >
+          <p>{content}</p>
+          <div className='tooltip-arrow' data-popper-arrow></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Tooltip;

--- a/src/components/feature/AutoPlan/index.tsx
+++ b/src/components/feature/AutoPlan/index.tsx
@@ -9,6 +9,7 @@ import MealCalendar from '@/components/shared/Meal/MealCalender';
 import MealHeader from '@/components/shared/Meal/MealHeader';
 import { MOCK_CATEGORY_LIST } from '@/constants/_category';
 import { INFOCARD_MESSAGE } from '@/constants/_infoCard';
+import { PAGE_TITLE } from '@/constants/_pageTitle';
 import { MEAL_HEADER_ERROR } from '@/constants/_schema';
 import { useToastStore } from '@/stores/useToastStore';
 
@@ -82,6 +83,7 @@ const AutoPlan = () => {
             selectedCategory={selectedCategory}
             handleChangeCategory={handleChangeCategory}
             isCategoryError={isCategoryError}
+            pageHeaderTitle={PAGE_TITLE.autoPlan.default}
           />
           <MealCalendar
             selectedCategory={selectedCategory}

--- a/src/components/feature/AutoPlanCreate/index.tsx
+++ b/src/components/feature/AutoPlanCreate/index.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
 import MealCreateHeader from '@/components/shared/Meal/MealCreateHeader';
 import { MOCK_CALENDAR_NUTRITION } from '@/constants/_calendarData';
+import { PAGE_TITLE } from '@/constants/_pageTitle';
 
 const AutoPlanCreate = () => {
   const [selectedDate, setSelectedDate] = useState<string>('');
@@ -33,6 +34,7 @@ const AutoPlanCreate = () => {
       <fieldset className='flex w-fit flex-col gap-4'>
         <legend className='sr-only'>자동 식단 이름 및 카테고리 등록</legend>
         <MealCreateHeader
+          pageHeaderTitle={PAGE_TITLE.autoPlan.create}
           inputValue={mealName}
           seletedCategory={seletedCategory}
         />

--- a/src/components/feature/AutoPlanEdit/index.tsx
+++ b/src/components/feature/AutoPlanEdit/index.tsx
@@ -10,6 +10,7 @@ import MealHeader from '@/components/shared/Meal/MealHeader';
 import { NutritionData } from '@/components/shared/Meal/NutritionInfo';
 import { MOCK_CALENDAR_NUTRITION } from '@/constants/_calendarData';
 import { MOCK_CATEGORY_LIST } from '@/constants/_category';
+import { PAGE_TITLE } from '@/constants/_pageTitle';
 import { MEAL_HEADER_ERROR } from '@/constants/_schema';
 import { useToastStore } from '@/stores/useToastStore';
 
@@ -102,7 +103,7 @@ const AutoPlanEdit = () => {
           errors={errors}
           selectedCategory={selectedCategory}
           handleChangeCategory={handleChangeCategory}
-          isPageEdit
+          pageHeaderTitle={PAGE_TITLE.autoPlan.edit}
         />
         <MealCalendar
           type='edit'

--- a/src/components/feature/MenualPlan/index.tsx
+++ b/src/components/feature/MenualPlan/index.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { mealHeaderSchema } from '@/schema/mealSchema';
+import { CalendarNutritionData } from '@/type/mealType';
+import { isValidDateString } from '@/utils/calendar';
+import MealCalendar from '@/components/shared/Meal/MealCalender';
+import MealHeader from '@/components/shared/Meal/MealHeader';
+import { NutritionData } from '@/components/shared/Meal/NutritionInfo';
+import { MOCK_CATEGORY_LIST } from '@/constants/_category';
+import { PAGE_TITLE } from '@/constants/_pageTitle';
+import { MEAL_HEADER_ERROR } from '@/constants/_schema';
+import { useToastStore } from '@/stores/useToastStore';
+
+const MenualPlan = () => {
+  // api로부터 전달받는 값
+  const currentYear = 2024;
+  const currentMonth = 9;
+
+  const [totalMenuList, setTotalMenuList] = useState<CalendarNutritionData>({});
+  const [selectedDate, setSelectedDate] = useState<string>('');
+  const [selectedCategory, setSelectedCategory] = useState({
+    organization: '',
+    organizationDetail: '',
+  });
+  const [isCategoryError, setIsCategoryError] = useState(false);
+
+  const { showToast } = useToastStore();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm({
+    resolver: zodResolver(mealHeaderSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: '',
+    },
+  });
+
+  const handleSaveMenu = (date: string, menuList: NutritionData[]) => {
+    setTotalMenuList((prevList) => ({
+      ...prevList,
+      [date]: [...menuList],
+    }));
+  };
+
+  const handleChangeCategory = (
+    type: 'organization' | 'organizationDetail',
+    value: string,
+  ) => {
+    setSelectedCategory((prev) => ({
+      ...prev,
+      [type]: value,
+    }));
+    setIsCategoryError(false);
+  };
+
+  const handleDateClick = (date: string) => {
+    if (isValidDateString(date)) setSelectedDate(date);
+  };
+
+  const handleResetMenu = () => {
+    setTotalMenuList({});
+    setSelectedDate('');
+  };
+
+  // TODO: 식단 이름, 카테고리, 전체 식단 제출 및 식단 조회로 이동
+  const onSubmit = (data: { name: string }) => {
+    console.log(data);
+    const { organization, organizationDetail } = selectedCategory;
+
+    const isSelectedCategoryInvalid =
+      organization === '' || organizationDetail === '';
+
+    if (isSelectedCategoryInvalid) {
+      showToast(MEAL_HEADER_ERROR.category.min, 'warning', 3000);
+      setIsCategoryError(true);
+      return;
+    }
+  };
+
+  const onError = () => {
+    if (errors.name) {
+      showToast(MEAL_HEADER_ERROR.name.min, 'warning', 3000);
+      return;
+    }
+  };
+
+  return (
+    <div className='flex gap-8'>
+      <form onSubmit={handleSubmit(onSubmit, onError)}>
+        <fieldset className='flex w-fit flex-col gap-4'>
+          <legend className='sr-only'>수동 식단 작성</legend>
+          <MealHeader
+            categories={MOCK_CATEGORY_LIST}
+            register={register}
+            errors={errors}
+            selectedCategory={selectedCategory}
+            handleChangeCategory={handleChangeCategory}
+            isCategoryError={isCategoryError}
+            pageHeaderTitle={PAGE_TITLE.menualPlan.default}
+          />
+          <MealCalendar
+            type='menualCreate'
+            selectedCategory={selectedCategory}
+            isValid={isValid}
+            year={currentYear}
+            month={currentMonth}
+            data={totalMenuList}
+            onDateClick={handleDateClick}
+            selectedDate={selectedDate}
+            handleSaveMenu={handleSaveMenu}
+            handleResetMenu={handleResetMenu}
+          />
+        </fieldset>
+      </form>
+    </div>
+  );
+};
+
+export default MenualPlan;

--- a/src/components/shared/Meal/MealCalender/index.tsx
+++ b/src/components/shared/Meal/MealCalender/index.tsx
@@ -3,6 +3,7 @@
 import Button from '@/components/common/Button/Button';
 import Calendar, { CalendarProps } from '@/components/common/Calendar';
 import { MealCalenderTitle } from '@/components/common/Typography';
+import MealCreate from '@/components/shared/Meal/MealCreate';
 import MealEdit from '@/components/shared/Meal/MealEdit';
 import NutritionInfo, {
   NutritionData,
@@ -14,7 +15,7 @@ export type Category = {
 };
 
 type MealCalendarProps = {
-  type?: 'default' | 'create' | 'edit';
+  type?: 'default' | 'create' | 'edit' | 'menualCreate';
   selectedCategory?: Category;
   isValid?: boolean;
   selectedDate?: string;
@@ -22,13 +23,14 @@ type MealCalendarProps = {
     date: string,
     menuName: string,
     updatedItem: NutritionData,
+    type: 'edit' | 'add',
   ) => void;
   handleResetMenu?: () => void;
 } & CalendarProps;
 
 const MealCalendar = ({
   type = 'default',
-  selectedDate,
+  selectedDate = '',
   year,
   month,
   data,
@@ -76,6 +78,22 @@ const MealCalendar = ({
               </Button>
             </div>
           )}
+          {type === 'menualCreate' && (
+            <div className='flex w-fit items-center gap-2'>
+              <Button
+                className='h-10 w-fit'
+                size='basic'
+                variant='outline'
+                type='button'
+                onClick={handleResetMenu}
+              >
+                메뉴초기화
+              </Button>
+              <Button className='h-10 w-fit' size='basic' type='submit'>
+                생성
+              </Button>
+            </div>
+          )}
         </div>
         <Calendar
           year={year}
@@ -85,15 +103,21 @@ const MealCalendar = ({
           onDateClick={onDateClick}
         />
       </div>
-      {(type === 'create' || type === 'edit') && selectedDate && data && (
+      {selectedDate && (
         <div className='mt-[56px]'>
-          {type === 'create' && (
+          {type === 'create' && data && (
             <NutritionInfo date={selectedDate} data={data[selectedDate]} />
           )}
-          {type === 'edit' && (
+          {type === 'edit' && data && (
             <MealEdit
               date={selectedDate}
               data={data[selectedDate]}
+              handleChangeMenu={handleChangeMenu}
+            />
+          )}
+          {type === 'menualCreate' && (
+            <MealCreate
+              date={selectedDate}
               handleChangeMenu={handleChangeMenu}
             />
           )}

--- a/src/components/shared/Meal/MealCalender/index.tsx
+++ b/src/components/shared/Meal/MealCalender/index.tsx
@@ -26,6 +26,7 @@ type MealCalendarProps = {
     type: 'edit' | 'add',
   ) => void;
   handleResetMenu?: () => void;
+  handleSaveMenu?: (date: string, menuList: NutritionData[]) => void;
 } & CalendarProps;
 
 const MealCalendar = ({
@@ -38,6 +39,7 @@ const MealCalendar = ({
   onDateClick,
   handleChangeMenu,
   handleResetMenu,
+  handleSaveMenu,
 }: MealCalendarProps) => {
   return (
     <div className='flex gap-8'>
@@ -116,10 +118,7 @@ const MealCalendar = ({
             />
           )}
           {type === 'menualCreate' && (
-            <MealCreate
-              date={selectedDate}
-              handleChangeMenu={handleChangeMenu}
-            />
+            <MealCreate date={selectedDate} handleSaveMenu={handleSaveMenu} />
           )}
         </div>
       )}

--- a/src/components/shared/Meal/MealCreate/index.tsx
+++ b/src/components/shared/Meal/MealCreate/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { cn } from '@/utils/core';
 import Button from '@/components/common/Button/Button';
 import { MAXIUM_MENU_PER_DAY } from '@/components/common/CalendarDay';
+import Tooltip from '@/components/common/Tooltip';
 import KcalInfo from '@/components/shared/Meal/KcalInfo';
 import MealInfoContainer from '@/components/shared/Meal/MealInfoContainer';
 import MealSearchContainer from '@/components/shared/Meal/MealSearchContainer';
@@ -131,14 +132,19 @@ const MealCreate = ({ date, handleSaveMenu }: MealCreateProps) => {
             >
               식단 저장
             </Button>
-            <Button
-              type='button'
-              variant='secondary'
-              className='y-2 h-fit w-fit p-2'
-              onClick={handleDeleteMenu}
+            <Tooltip
+              content='삭제하고 싶은 메뉴를 클릭 후 메뉴 삭제 버튼을 눌러주세요.'
+              position='bottom'
             >
-              메뉴 삭제
-            </Button>
+              <Button
+                type='button'
+                variant='secondary'
+                className='y-2 h-fit w-fit p-2'
+                onClick={handleDeleteMenu}
+              >
+                메뉴 삭제
+              </Button>
+            </Tooltip>
             <Button
               type='button'
               variant='secondary'

--- a/src/components/shared/Meal/MealCreate/index.tsx
+++ b/src/components/shared/Meal/MealCreate/index.tsx
@@ -1,0 +1,192 @@
+import { useEffect, useState } from 'react';
+import Button from '@/components/common/Button/Button';
+import { MAXIUM_MENU_PER_DAY } from '@/components/common/CalendarDay';
+import KcalInfo from '@/components/shared/Meal/KcalInfo';
+import MealInfoContainer from '@/components/shared/Meal/MealInfoContainer';
+import MealSearchContainer from '@/components/shared/Meal/MealSearchContainer';
+import { NutritionData } from '@/components/shared/Meal/NutritionInfo';
+import NutritionMenuButton from '@/components/shared/Meal/NutritionMenuButton';
+import { MOCK_ALL_MENU } from '@/constants/_calendarData';
+import { MEAL_CREATE_MESSAGE } from '@/constants/_toastMessage';
+import { useToastStore } from '@/stores/useToastStore';
+
+type MealCreateProps = {
+  date: string;
+  handleChangeMenu?: (
+    date: string,
+    menuName: string,
+    updatedItem: NutritionData,
+    type: 'edit' | 'add',
+  ) => void;
+};
+
+const MealCreate = ({ date, handleChangeMenu }: MealCreateProps) => {
+  const [allMenuList, setAllMenuList] = useState<{
+    [key: string]: NutritionData[];
+  }>({});
+  const [menuList, setMenuList] = useState<NutritionData[]>([]);
+  const [clickedMenu, setClickedMenu] = useState<string | null>(null);
+  const [keyword, setKeyword] = useState('');
+  const [isSearchShow, setIsSearchShow] = useState(false);
+  const [searchResultList] = useState<NutritionData[]>(MOCK_ALL_MENU);
+  const { showToast } = useToastStore();
+
+  const handleClickAddMenu = () => {
+    setIsSearchShow(true);
+  };
+
+  const handleClickMenu = (menu: string) => {
+    setKeyword(menu);
+    setClickedMenu(menu);
+    setIsSearchShow(true);
+  };
+
+  const handleSearchClick = () => {
+    // api 요청
+  };
+
+  const handleDeleteMenu = () => {
+    if (clickedMenu) {
+      setMenuList((prevList) =>
+        prevList.filter((item) => item.content !== clickedMenu),
+      );
+      setClickedMenu(null);
+      setKeyword('');
+    } else {
+      showToast(MEAL_CREATE_MESSAGE.error.notSelected, 'warning');
+    }
+  };
+
+  const handleResetMenu = () => {
+    setMenuList([]);
+    setClickedMenu(null);
+    setKeyword('');
+  };
+
+  const handleClickNewMenu = (menu: string) => {
+    const result = searchResultList.find((item) => item.content === menu);
+
+    if (result && handleChangeMenu) {
+      const isDuplicate = menuList.some(
+        (item) => item.content === result.content,
+      );
+
+      if (isDuplicate) {
+        showToast(MEAL_CREATE_MESSAGE.error.duplicate, 'warning');
+        return;
+      }
+
+      setMenuList((prevList) => {
+        if (prevList.length < MAXIUM_MENU_PER_DAY) {
+          if (clickedMenu) {
+            const updatedMenuList = prevList.map((item) =>
+              item.content === clickedMenu ? result : item,
+            );
+            return updatedMenuList;
+          } else {
+            const addedMenuList = [...prevList, result];
+            return addedMenuList;
+          }
+        } else {
+          showToast(MEAL_CREATE_MESSAGE.error.exceed, 'warning');
+          return prevList;
+        }
+      });
+    }
+    setKeyword(menu);
+  };
+
+  const handleSaveMeal = () => {
+    setAllMenuList((prevAllMenuList) => ({
+      ...prevAllMenuList,
+      [date]: menuList,
+    }));
+
+    menuList.forEach((menu) => {
+      if (handleChangeMenu) {
+        handleChangeMenu(date, menu.content, menu, 'add');
+      }
+    });
+
+    showToast(`${date} ${MEAL_CREATE_MESSAGE.success.saveMeal}`, 'success');
+  };
+
+  useEffect(() => {
+    const savedMenu = allMenuList[date] || [];
+    setMenuList(savedMenu);
+    setClickedMenu('');
+    setKeyword('');
+    setIsSearchShow(false);
+  }, [date, allMenuList]);
+
+  return (
+    <MealInfoContainer date={date}>
+      <div className='flex w-full flex-col gap-2'>
+        {isSearchShow && (
+          <div className='ml-auto flex gap-2'>
+            <Button
+              type='button'
+              variant='outline'
+              className='y-2 h-fit w-fit p-2'
+              onClick={handleSaveMeal}
+            >
+              식단 저장
+            </Button>
+            <Button
+              type='button'
+              variant='secondary'
+              className='y-2 h-fit w-fit p-2'
+              onClick={handleDeleteMenu}
+            >
+              메뉴 삭제
+            </Button>
+            <Button
+              type='button'
+              variant='secondary'
+              className='y-2 h-fit w-fit p-2'
+              onClick={handleResetMenu}
+            >
+              메뉴 초기화
+            </Button>
+          </div>
+        )}
+        <div className='flex w-full flex-col gap-1'>
+          {menuList.map((item) => (
+            <NutritionMenuButton
+              key={item.id}
+              menuName={item.content}
+              className={
+                clickedMenu === item.content
+                  ? 'bg-green-200 hover:bg-green-200'
+                  : ''
+              }
+              onFocus={() => setIsSearchShow(true)}
+              onClick={() => handleClickMenu(item.content)}
+            />
+          ))}
+          {menuList.length < 1 && !isSearchShow && (
+            <Button
+              type='button'
+              variant='primary'
+              onClick={handleClickAddMenu}
+            >
+              메뉴 등록하기
+            </Button>
+          )}
+          <KcalInfo data={menuList} />
+        </div>
+        {isSearchShow && keyword.length >= 0 && (
+          <MealSearchContainer
+            keyword={keyword}
+            searchResultList={searchResultList}
+            onChange={(e) => setKeyword(e.target.value)}
+            onSubmit={handleSearchClick}
+            onClickNewMenu={handleClickNewMenu}
+          />
+        )}
+      </div>
+    </MealInfoContainer>
+  );
+};
+
+export default MealCreate;

--- a/src/components/shared/Meal/MealCreate/index.tsx
+++ b/src/components/shared/Meal/MealCreate/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { cn } from '@/utils/core';
 import Button from '@/components/common/Button/Button';
 import { MAXIUM_MENU_PER_DAY } from '@/components/common/CalendarDay';
 import KcalInfo from '@/components/shared/Meal/KcalInfo';
@@ -92,6 +93,11 @@ const MealCreate = ({ date, handleSaveMenu }: MealCreateProps) => {
   };
 
   const handleSaveMeal = () => {
+    if (menuList.length === 0) {
+      showToast('저장할 메뉴를 검색창에서 선택해주세요.', 'warning');
+      return;
+    }
+
     setAllMenuList((prevAllMenuList) => ({
       ...prevAllMenuList,
       [date]: menuList,
@@ -143,29 +149,36 @@ const MealCreate = ({ date, handleSaveMenu }: MealCreateProps) => {
             </Button>
           </div>
         )}
-        <div className='flex w-full flex-col gap-1'>
-          {menuList.map((item) => (
-            <NutritionMenuButton
-              key={item.id}
-              menuName={item.content}
-              className={
-                clickedMenu === item.content
-                  ? 'bg-green-200 hover:bg-green-200'
-                  : ''
-              }
-              onFocus={() => setIsSearchShow(true)}
-              onClick={() => handleClickMenu(item.content)}
-            />
-          ))}
-          {menuList.length < 1 && !isSearchShow && (
-            <Button
-              type='button'
-              variant='primary'
-              onClick={handleClickAddMenu}
-            >
-              메뉴 등록하기
-            </Button>
-          )}
+        <div className='flex w-full flex-col gap-2'>
+          <div
+            className={cn(
+              'flex w-full flex-col gap-1',
+              isSearchShow ? 'h-[302px]' : '',
+            )}
+          >
+            {menuList.map((item) => (
+              <NutritionMenuButton
+                key={item.id}
+                menuName={item.content}
+                className={
+                  clickedMenu === item.content
+                    ? 'bg-green-200 hover:bg-green-200'
+                    : ''
+                }
+                onFocus={() => setIsSearchShow(true)}
+                onClick={() => handleClickMenu(item.content)}
+              />
+            ))}
+            {menuList.length < 1 && !isSearchShow && (
+              <Button
+                type='button'
+                variant='primary'
+                onClick={handleClickAddMenu}
+              >
+                메뉴 등록하기
+              </Button>
+            )}
+          </div>
           <KcalInfo data={menuList} />
         </div>
         {isSearchShow && keyword.length >= 0 && (

--- a/src/components/shared/Meal/MealCreate/index.tsx
+++ b/src/components/shared/Meal/MealCreate/index.tsx
@@ -12,15 +12,10 @@ import { useToastStore } from '@/stores/useToastStore';
 
 type MealCreateProps = {
   date: string;
-  handleChangeMenu?: (
-    date: string,
-    menuName: string,
-    updatedItem: NutritionData,
-    type: 'edit' | 'add',
-  ) => void;
+  handleSaveMenu?: (date: string, menuList: NutritionData[]) => void;
 };
 
-const MealCreate = ({ date, handleChangeMenu }: MealCreateProps) => {
+const MealCreate = ({ date, handleSaveMenu }: MealCreateProps) => {
   const [allMenuList, setAllMenuList] = useState<{
     [key: string]: NutritionData[];
   }>({});
@@ -66,7 +61,7 @@ const MealCreate = ({ date, handleChangeMenu }: MealCreateProps) => {
   const handleClickNewMenu = (menu: string) => {
     const result = searchResultList.find((item) => item.content === menu);
 
-    if (result && handleChangeMenu) {
+    if (result && handleSaveMenu) {
       const isDuplicate = menuList.some(
         (item) => item.content === result.content,
       );
@@ -102,11 +97,9 @@ const MealCreate = ({ date, handleChangeMenu }: MealCreateProps) => {
       [date]: menuList,
     }));
 
-    menuList.forEach((menu) => {
-      if (handleChangeMenu) {
-        handleChangeMenu(date, menu.content, menu, 'add');
-      }
-    });
+    if (handleSaveMenu) {
+      handleSaveMenu(date, menuList);
+    }
 
     showToast(`${date} ${MEAL_CREATE_MESSAGE.success.saveMeal}`, 'success');
   };

--- a/src/components/shared/Meal/MealCreate/index.tsx
+++ b/src/components/shared/Meal/MealCreate/index.tsx
@@ -63,33 +63,34 @@ const MealCreate = ({ date, handleSaveMenu }: MealCreateProps) => {
   const handleClickNewMenu = (menu: string) => {
     const result = searchResultList.find((item) => item.content === menu);
 
-    if (result && handleSaveMenu) {
-      const isDuplicate = menuList.some(
-        (item) => item.content === result.content,
-      );
+    if (!result || !handleSaveMenu) {
+      return;
+    }
 
-      if (isDuplicate) {
-        showToast(MEAL_CREATE_MESSAGE.error.duplicate, 'warning');
-        return;
+    const isDuplicate = menuList.some(
+      (item) => item.content === result.content,
+    );
+
+    if (isDuplicate) {
+      showToast(MEAL_CREATE_MESSAGE.error.duplicate, 'warning');
+      return;
+    }
+
+    setMenuList((prevList) => {
+      if (prevList.length >= MAXIUM_MENU_PER_DAY) {
+        showToast(MEAL_CREATE_MESSAGE.error.exceed, 'warning');
+        return prevList;
       }
 
-      setMenuList((prevList) => {
-        if (prevList.length < MAXIUM_MENU_PER_DAY) {
-          if (clickedMenu) {
-            const updatedMenuList = prevList.map((item) =>
-              item.content === clickedMenu ? result : item,
-            );
-            return updatedMenuList;
-          } else {
-            const addedMenuList = [...prevList, result];
-            return addedMenuList;
-          }
-        } else {
-          showToast(MEAL_CREATE_MESSAGE.error.exceed, 'warning');
-          return prevList;
-        }
-      });
-    }
+      if (clickedMenu) {
+        return prevList.map((item) =>
+          item.content === clickedMenu ? result : item,
+        );
+      }
+
+      return [...prevList, result];
+    });
+
     setKeyword(menu);
   };
 

--- a/src/components/shared/Meal/MealCreateHeader/index.tsx
+++ b/src/components/shared/Meal/MealCreateHeader/index.tsx
@@ -1,20 +1,21 @@
 import { Input } from '@/components/common/Input';
 import { Selectbox } from '@/components/common/Selectbox';
 import { PageHeaderTitle } from '@/components/common/Typography';
-import { PAGE_TITLE } from '@/constants/_pageTitle';
 
 type MealCreateHeaderProps = {
   inputValue: string;
   seletedCategory: string[];
+  pageHeaderTitle: string;
 };
 
 const MealCreateHeader = ({
   inputValue,
   seletedCategory,
+  pageHeaderTitle,
 }: MealCreateHeaderProps) => {
   return (
     <div className='flex flex-col gap-5'>
-      <PageHeaderTitle>{PAGE_TITLE.autoPlan.create}</PageHeaderTitle>
+      <PageHeaderTitle>{pageHeaderTitle}</PageHeaderTitle>
       <div className='flex w-fit items-center gap-4'>
         <Input
           className='text-lg font-semibold focus:border-green-400'

--- a/src/components/shared/Meal/MealEdit/index.tsx
+++ b/src/components/shared/Meal/MealEdit/index.tsx
@@ -71,21 +71,19 @@ const MealEdit = ({ date, data, handleChangeMenu }: MealEditProps) => {
   return (
     <MealInfoContainer date={date}>
       <div className='flex w-full flex-col gap-1'>
-        {data.map((item) => {
-          return (
-            <NutritionMenuButton
-              key={item.id}
-              menuName={item.content}
-              className={
-                clickedMenu === item.content
-                  ? 'bg-green-200 hover:bg-green-200'
-                  : ''
-              }
-              onFocus={() => setIsSearchShow(true)}
-              onClick={() => handleClickMenu(item.content)}
-            />
-          );
-        })}
+        {data.map((item) => (
+          <NutritionMenuButton
+            key={item.id}
+            menuName={item.content}
+            className={
+              clickedMenu === item.content
+                ? 'bg-green-200 hover:bg-green-200'
+                : ''
+            }
+            onFocus={() => setIsSearchShow(true)}
+            onClick={() => handleClickMenu(item.content)}
+          />
+        ))}
         <KcalInfo data={data} />
       </div>
       {isSearchShow && keyword!.length >= 0 && (

--- a/src/components/shared/Meal/MealHeader/index.tsx
+++ b/src/components/shared/Meal/MealHeader/index.tsx
@@ -6,7 +6,6 @@ import { Input } from '@/components/common/Input';
 import { Option, Selectbox } from '@/components/common/Selectbox';
 import { PageHeaderTitle } from '@/components/common/Typography';
 import { ORGANIZATION_LIST } from '@/constants/_category';
-import { PAGE_TITLE } from '@/constants/_pageTitle';
 
 type MealHeaderFormData = {
   name: string;
@@ -25,10 +24,8 @@ type MealHeaderProps = {
     value: string,
   ) => void;
   isCategoryError?: boolean;
-  isPageEdit?: boolean;
+  pageHeaderTitle: string;
 };
-
-const { autoPlan } = PAGE_TITLE;
 
 const MealHeader = ({
   categories,
@@ -37,13 +34,11 @@ const MealHeader = ({
   selectedCategory,
   handleChangeCategory,
   isCategoryError,
-  isPageEdit,
+  pageHeaderTitle,
 }: MealHeaderProps) => {
   return (
     <div className='flex flex-col gap-5'>
-      <PageHeaderTitle>
-        {isPageEdit ? autoPlan.edit : autoPlan.default}
-      </PageHeaderTitle>
+      <PageHeaderTitle>{pageHeaderTitle}</PageHeaderTitle>
       <div className='flex w-full items-center gap-4'>
         <div className='relative flex h-fit flex-col'>
           <Input

--- a/src/components/shared/Meal/MealSearchContainer/index.tsx
+++ b/src/components/shared/Meal/MealSearchContainer/index.tsx
@@ -30,7 +30,7 @@ const MealSearchContainer = ({
         onSubmit={onSubmit}
         value={keyword || ''}
       />
-      <div className='custom-scrollbar max-h-[470px] w-full overflow-y-auto rounded-md bg-white-200 p-2'>
+      <div className='scrollbar-gray-100 max-h-[380px] w-full overflow-y-auto rounded-md bg-white-200 p-2'>
         {searchResultList.length === 0 ? (
           <NutritionMenu>메뉴가 존재하지 않습니다</NutritionMenu>
         ) : (

--- a/src/components/shared/Meal/MealSearchContainer/index.tsx
+++ b/src/components/shared/Meal/MealSearchContainer/index.tsx
@@ -1,0 +1,48 @@
+import { ChangeEvent } from 'react';
+import { Input } from '@/components/common/Input';
+import { NutritionMenu } from '@/components/common/Typography';
+import MealTable from '@/components/shared/Meal/MealTable';
+import { NutritionData } from '@/components/shared/Meal/NutritionInfo';
+
+type MealSearchContainerProps = {
+  keyword: string;
+  searchResultList: NutritionData[];
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: () => void;
+  onClickNewMenu: (menu: string) => void;
+};
+
+const MealSearchContainer = ({
+  keyword,
+  searchResultList,
+  onChange,
+  onSubmit,
+  onClickNewMenu,
+}: MealSearchContainerProps) => {
+  return (
+    <div className='flex w-full flex-col gap-2'>
+      <Input
+        className='text-md placeholder:text-md font-semibold'
+        placeholder='메뉴 이름을 입력해주세요'
+        bgcolor='search'
+        includeButton
+        onChange={(e) => onChange(e)}
+        onSubmit={onSubmit}
+        value={keyword || ''}
+      />
+      <div className='custom-scrollbar max-h-[470px] w-full overflow-y-auto rounded-md bg-white-200 p-2'>
+        {searchResultList.length === 0 ? (
+          <NutritionMenu>메뉴가 존재하지 않습니다</NutritionMenu>
+        ) : (
+          <MealTable
+            data={searchResultList}
+            isButton
+            onClick={onClickNewMenu}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MealSearchContainer;

--- a/src/components/shared/Meal/MealTable/index.tsx
+++ b/src/components/shared/Meal/MealTable/index.tsx
@@ -1,4 +1,3 @@
-import { memo } from 'react';
 import Table from '@/components/common/Table';
 import { NutritionMenu } from '@/components/common/Typography';
 import { NutritionData } from '@/components/shared/Meal/NutritionInfo';
@@ -35,6 +34,7 @@ const MealTable = ({ data, isButton = false, onClick }: MealTableProps) => {
 
         return isButton ? (
           <button
+            type='button'
             key={item.id}
             className='flex w-full flex-col gap-0.5 rounded-md p-2 text-left transition duration-300 ease-in-out hover:bg-gray-100 active:bg-gray-200'
             onClick={() => onClick?.(item.content)}
@@ -55,4 +55,4 @@ const MealTable = ({ data, isButton = false, onClick }: MealTableProps) => {
   );
 };
 
-export default memo(MealTable);
+export default MealTable;

--- a/src/components/shared/Meal/NutritionMenuButton/index.tsx
+++ b/src/components/shared/Meal/NutritionMenuButton/index.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/utils/core';
+import Icon from '@/components/common/Icon';
+import { NutritionMenu } from '@/components/common/Typography';
+
+type NutritionMenuButtonProps = {
+  menuName: string;
+  className?: string;
+  onFocus: () => void;
+  onClick: () => void;
+};
+
+const NutritionMenuButton = ({
+  menuName,
+  className,
+  onFocus,
+  onClick,
+}: NutritionMenuButtonProps) => {
+  return (
+    <button
+      type='button'
+      className={cn(
+        'flex w-full justify-between rounded-md p-2 transition duration-300 ease-in-out hover:bg-green-100 hover:text-gray-900 focus:bg-green-200 active:bg-green-200',
+        className,
+      )}
+      onFocus={onFocus}
+      onClick={onClick}
+    >
+      <NutritionMenu>{menuName}</NutritionMenu>
+      <Icon name='edit' />
+    </button>
+  );
+};
+
+export default NutritionMenuButton;

--- a/src/constants/_pageTitle.ts
+++ b/src/constants/_pageTitle.ts
@@ -4,4 +4,13 @@ export const PAGE_TITLE = {
     edit: '자동 식단 수정',
     create: '자동 식단 생성',
   },
+  menualPlan: {
+    default: '수동 식단 작성',
+    edit: '수동 식단 수정',
+    create: '수동 식단 생성',
+  },
+  created: {
+    default: '생성한 식단 상세',
+    edit: '생성한 식단 수정',
+  },
 };

--- a/src/constants/_toastMessage.ts
+++ b/src/constants/_toastMessage.ts
@@ -1,0 +1,10 @@
+export const MEAL_CREATE_MESSAGE = {
+  error: {
+    exceed: '메뉴는 최대 7개까지 등록할 수 있습니다.',
+    duplicate: '중복되는 메뉴는 추가할 수 없습니다.',
+    notSelected: '삭제할 메뉴가 선택되지 않았습니다.',
+  },
+  success: {
+    saveMeal: '식단이 저장되었습니다.',
+  },
+};


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->
## 유형

- [x] 기능 구현
- [x] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 수동 식단 작성 페이지 구현

### 설명 (선택)

### Feat
1. 페이지별 제목 및 토스트 메시지 객체화
2. 메뉴 검색에 사용되는 기존 식단 메뉴 버튼 NutritionMenuButton 컴포넌트로 분리
3. 메뉴 검색 컨테이너 MealSearchContainr 컴포넌트로 분리
4. 수동 식단 작성 페이지에서 사용되는 메뉴 추가 및 변경 가능한 MealCreate 구현
5. 수동 식단 작성 페이지 구현
6. 툴팁 컴포넌트 적용 및 MealCreate 메뉴 삭제 버튼에 적용

### Refactor
1. MealTable 컴포넌트 memo 적용 해제
2. 식단 header 페이지 제목 prop으로 추가
3. 자동 식단 페이지 제목 객체로 전달
4. MAXIMUM MENU PER DAY 변수 export로 수정
5. type prop 추가, 중복 메뉴 추가 방지 로직 구현, 중복 코드 shared 컴포넌트로 분리
7. MealCalendar menualCreate type 추가, 렌더링 조건문 수정

### Fix
1. Table border 깎여보이는 문제 해결, TableBody onClick prop 추가
![image](https://github.com/user-attachments/assets/503c9f6d-e26a-411d-98d0-47386443f176)
2. Calendar 열 고정 width 반응형 추가, CalendarDay w-full로 수정
3.  husky script 중 필요없는 명령어 삭제
- 자꾸 commit 남길 때마다 터미널에 husky v.10부터는 지원하지 않는 명령어가 있다고 경고문이 떠서 수정했습니다~


## 스크린샷
### 수동 식단 작성 페이지
![image](https://github.com/user-attachments/assets/e0e7ed77-f594-4aef-8454-8e3b066017a8)
![image](https://github.com/user-attachments/assets/6b2a5d55-24a1-43b3-a01d-75d707864d81)
![image](https://github.com/user-attachments/assets/935ade0b-e518-43db-bca6-3bd91457f479)
![image](https://github.com/user-attachments/assets/0a7f73e3-81e8-4a93-ace2-8a23b7b7cd2f)
![image](https://github.com/user-attachments/assets/68d69588-d044-4ffb-a375-511510df14ce)
![image](https://github.com/user-attachments/assets/11a3ad60-b3a1-4e05-a83e-715c93d3ab45)

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- 기존 식단 페이지들에서 중복되는 코드들 NutiritonMenuButton(연필 모양 메뉴 버튼), MealSearchContainer(메뉴 수정 및 검색 가능한 컨테이너) 등으로 분리하였습니다. 그러다보니 새로 추가한 코드가 많아 보이네요 😅 
- 캘린더에서 오른쪽 선이 보이지 않는 문제 : 각 day들의 너비가 양 옆을 침범하고 있어서 그랬던 것 같습니다. 각 day에 줬던 고정 width 없애고, 캘린더 너비 자체를 고정으로 주었습니다. 반응형이라고 하기 뭐하게 주긴 줬는데 이 부분은 반응형 디자인이 없는 상황이라 애매한 것 같습니다... 저는 이제 캘린더 오른쪽 선이 잘 보이는데, 승현님께서도 44번 브랜치에서 캘린더 잘 고쳐졌는지 한 번 확인해주시면 감사하겠습니다!