### PR TITLE
Feat[#THKV-58] : 식단 상세 및 수정 페이지 구현

### DIFF
--- a/src/app/(root)/mealPlan/edit/page.tsx
+++ b/src/app/(root)/mealPlan/edit/page.tsx
@@ -1,0 +1,7 @@
+import MealPlanEdit from '@/components/feature/MealPlanEdit';
+
+const page = () => {
+  return <MealPlanEdit />;
+};
+
+export default page;

--- a/src/app/(root)/mealPlan/page.tsx
+++ b/src/app/(root)/mealPlan/page.tsx
@@ -1,0 +1,7 @@
+import MealPlan from '@/components/feature/MealPlan';
+
+const page = () => {
+  return <MealPlan />;
+};
+
+export default page;

--- a/src/components/feature/MealPlan/index.tsx
+++ b/src/components/feature/MealPlan/index.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import { getCurrentYearMonthNow } from '@/utils/calendar';
+import MealForm from '@/components/common/MealForm';
+import MealCalendar from '@/components/shared/Meal/MealCalender';
+import MealPlanHeader from '@/components/shared/MealPlanHeader';
+import { MOCK_CALENDAR_NUTRITION } from '@/constants/_calendarData';
+import { MEAL_FORM_LEGEND } from '@/constants/_MealForm';
+
+const MealPlan = () => {
+  const [selectedDate, setSelectedDate] = useState<string>('');
+
+  const { year } = getCurrentYearMonthNow();
+
+  // 임시 데이터
+  const month = 9;
+
+  const handleDateClick = (date: string) => {
+    setSelectedDate(date);
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // 엑셀 저장
+  };
+
+  // api로부터 전달받은 식단 이름, 카테고리
+  const mealName = '맛있는 9월 식단';
+  const selectedCategory = ['카테고리1', '카테고리2'];
+
+  return (
+    <MealForm
+      legend={MEAL_FORM_LEGEND.autoPlan.create}
+      handleSubmit={handleSubmit}
+    >
+      <MealPlanHeader mealName={mealName} selectedCategory={selectedCategory} />
+      <MealCalendar
+        type='mealPlan'
+        data={MOCK_CALENDAR_NUTRITION}
+        year={year}
+        month={month}
+        onDateClick={handleDateClick}
+        selectedDate={selectedDate}
+      />
+    </MealForm>
+  );
+};
+
+export default MealPlan;

--- a/src/components/feature/MealPlanEdit/index.tsx
+++ b/src/components/feature/MealPlanEdit/index.tsx
@@ -52,14 +52,16 @@ const MealPlanEdit = () => {
     updatedItem: NutritionData,
   ) => {
     setTotalMenuList((prevList) => {
-      const updatedList = { ...prevList };
-
-      if (updatedList[date]) {
-        updatedList[date] = updatedList[date].map((item) =>
-          item.content === menuName ? { ...item, ...updatedItem } : item,
-        );
+      if (!prevList[date]) {
+        return prevList;
       }
-      return updatedList;
+
+      return {
+        ...prevList,
+        [date]: prevList[date].map((item) =>
+          item.content === menuName ? { ...item, ...updatedItem } : item,
+        ),
+      };
     });
   };
 
@@ -98,9 +100,7 @@ const MealPlanEdit = () => {
   return (
     <MealForm
       legend={MEAL_FORM_LEGEND.mealPlan.edit}
-      handleSubmit={handleSubmit}
-      onSubmit={onSubmit}
-      onError={onError}
+      handleSubmit={handleSubmit(onSubmit, onError)}
     >
       <MealHeader
         categories={MOCK_CATEGORY_LIST}

--- a/src/components/feature/MealPlanEdit/index.tsx
+++ b/src/components/feature/MealPlanEdit/index.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useState } from 'react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import { mealHeaderSchema } from '@/schema/mealSchema';
+import { isValidDateString } from '@/utils/calendar';
+import MealForm from '@/components/common/MealForm';
+import MealCalendar from '@/components/shared/Meal/MealCalender';
+import MealHeader from '@/components/shared/Meal/MealHeader';
+import { NutritionData } from '@/components/shared/Meal/NutritionInfo';
+import { MOCK_CALENDAR_NUTRITION } from '@/constants/_calendarData';
+import { MOCK_CATEGORY_LIST } from '@/constants/_category';
+import { MEAL_FORM_LEGEND } from '@/constants/_MealForm';
+import { PAGE_TITLE } from '@/constants/_pageTitle';
+import { MEAL_HEADER_ERROR } from '@/constants/_schema';
+import { useToastStore } from '@/stores/useToastStore';
+
+const MealPlanEdit = () => {
+  // api로부터 전달 받는 값
+  const mealName = '맛있는 9월 식단 야호';
+  const category = {
+    organization: '학교명',
+    organizationDetail: '냠냠초등학교',
+  };
+  const currentYear = 2024;
+  const currentMonth = 9;
+
+  const [totalMenuList, setTotalMenuList] = useState(MOCK_CALENDAR_NUTRITION);
+  const [selectedDate, setSelectedDate] = useState<string>('');
+  const [selectedCategory, setSelectedCategory] = useState({
+    organization: category.organization,
+    organizationDetail: category.organizationDetail,
+  });
+  const showToast = useToastStore((state) => state.showToast);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(mealHeaderSchema),
+    mode: 'onChange',
+    defaultValues: {
+      name: mealName,
+    },
+  });
+
+  const handleChangeMenu = (
+    date: string,
+    menuName: string,
+    updatedItem: NutritionData,
+  ) => {
+    setTotalMenuList((prevList) => {
+      const updatedList = { ...prevList };
+
+      if (updatedList[date]) {
+        updatedList[date] = updatedList[date].map((item) =>
+          item.content === menuName ? { ...item, ...updatedItem } : item,
+        );
+      }
+      return updatedList;
+    });
+  };
+
+  const handleChangeCategory = (
+    type: 'organization' | 'organizationDetail',
+    value: string,
+  ) => {
+    setSelectedCategory((prev) => ({
+      ...prev,
+      [type]: value,
+    }));
+  };
+
+  const handleDateClick = (date: string) => {
+    if (isValidDateString(date)) setSelectedDate(date);
+  };
+
+  const handleResetMenu = () => {
+    // 메뉴 초기화 클릭 시 실행
+    setTotalMenuList(MOCK_CALENDAR_NUTRITION);
+    setSelectedDate('');
+  };
+
+  const onSubmit = (data: { name: string }) => {
+    // 선택한 카테고리 + 식단이름 제출 + 식단 리스트로 이동
+    console.log(data);
+  };
+
+  const onError = () => {
+    if (errors.name) {
+      showToast(MEAL_HEADER_ERROR.name.min, 'warning', 3000);
+      return;
+    }
+  };
+
+  return (
+    <MealForm
+      legend={MEAL_FORM_LEGEND.mealPlan.edit}
+      handleSubmit={handleSubmit}
+      onSubmit={onSubmit}
+      onError={onError}
+    >
+      <MealHeader
+        categories={MOCK_CATEGORY_LIST}
+        register={register}
+        errors={errors}
+        selectedCategory={selectedCategory}
+        handleChangeCategory={handleChangeCategory}
+        pageHeaderTitle={PAGE_TITLE.mealPlan.edit}
+      />
+      <MealCalendar
+        type='edit'
+        year={currentYear}
+        month={currentMonth}
+        data={totalMenuList}
+        onDateClick={handleDateClick}
+        selectedDate={selectedDate}
+        handleChangeMenu={handleChangeMenu}
+        handleResetMenu={handleResetMenu}
+      />
+    </MealForm>
+  );
+};
+
+export default MealPlanEdit;

--- a/src/components/shared/Meal/MealCalender/index.tsx
+++ b/src/components/shared/Meal/MealCalender/index.tsx
@@ -15,7 +15,7 @@ export type Category = {
 };
 
 type MealCalendarProps = {
-  type?: 'default' | 'create' | 'edit' | 'menualCreate';
+  type?: 'default' | 'create' | 'edit' | 'menualCreate' | 'mealPlan';
   selectedCategory?: Category;
   isValid?: boolean;
   selectedDate?: string;
@@ -96,6 +96,24 @@ const MealCalendar = ({
               </Button>
             </div>
           )}
+          {type === 'mealPlan' && (
+            <div className='flex w-fit items-center gap-2'>
+              <Button
+                className='h-10 w-fit'
+                size='basic'
+                variant='outline'
+                type='submit'
+              >
+                엑셀 저장
+              </Button>
+              <Button className='h-10 w-fit' size='basic' type='button'>
+                수정
+              </Button>
+              <Button className='h-10 w-fit' size='basic' type='button'>
+                삭제
+              </Button>
+            </div>
+          )}
         </div>
         <Calendar
           year={year}
@@ -105,7 +123,7 @@ const MealCalendar = ({
           onDateClick={onDateClick}
         />
       </div>
-      {selectedDate && type === 'create' && data && (
+      {selectedDate && (type === 'create' || type === 'mealPlan') && data && (
         <NutritionInfo date={selectedDate} data={data[selectedDate]} />
       )}
       {selectedDate && type === 'edit' && data && (

--- a/src/components/shared/MealPlanHeader/index.tsx
+++ b/src/components/shared/MealPlanHeader/index.tsx
@@ -1,0 +1,34 @@
+import { Selectbox } from '@/components/common/Selectbox';
+import { PageHeaderTitle } from '@/components/common/Typography';
+
+type MealPlanHeaderProps = {
+  mealName: string;
+  selectedCategory: string[];
+};
+
+const MealPlanHeader = ({
+  mealName,
+  selectedCategory,
+}: MealPlanHeaderProps) => {
+  return (
+    <div className='flex items-center gap-2'>
+      <PageHeaderTitle>{mealName}</PageHeaderTitle>
+      <div className='flex gap-2'>
+        <Selectbox
+          size='small'
+          selectedValue={selectedCategory[0]}
+          className='cursor-not-allowed focus:border-gray-300'
+          readonly={true}
+        />
+        <Selectbox
+          size='small'
+          selectedValue={selectedCategory[1]}
+          className='cursor-not-allowed focus:border-gray-300'
+          readonly={true}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default MealPlanHeader;

--- a/src/constants/_MealForm.ts
+++ b/src/constants/_MealForm.ts
@@ -7,4 +7,7 @@ export const MEAL_FORM_LEGEND = {
     create: '수동 식단 이름 및 카테고리 등록',
     edit: '자동 식단 이름 및 카테고리 등록',
   },
+  mealPlan: {
+    edit: '식단 수정',
+  },
 };

--- a/src/constants/_pageTitle.ts
+++ b/src/constants/_pageTitle.ts
@@ -9,7 +9,7 @@ export const PAGE_TITLE = {
     edit: '수동 식단 수정',
     create: '수동 식단 생성',
   },
-  created: {
+  mealPlan: {
     default: '생성한 식단 상세',
     edit: '생성한 식단 수정',
   },


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- 식단 상세 페이지 구현
- 식단 수정 페이지 구현

### 설명 (선택)
- 아직 수동식단 PR이 머지가 되지 않은 관계로 56번 브랜치에서 따서 작업했습니다.
- 식단 상세페이지 특성에 맞게 `MealPlanHeader` 컴포넌트 따로 만들어 적용했습니다.
- 식단 상세페이지용 버튼들(엑셀 저장, 삭제, 수정)이 필요한 관계로 `MealCalendar`에서 `type` 프롭에 `mealPlan`을 추가했습니다. 그리고 엑셀 버튼에 submit을 걸어서, 엑셀 저장 버튼을 누르면 엑셀 파일로 내보내기되도록 로직을 추가할 예정입니다!

## 스크린샷
### 식단 상세 페이지
![image](https://github.com/user-attachments/assets/c26c8b24-2c42-4202-8056-ea8dcaae8a65)

### 식단 수정 페이지
![image](https://github.com/user-attachments/assets/f20eda18-4fb8-44bb-89fc-e18d2ed26376)

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

1. 식단 상세 페이지는 후에 `viewPlan/[id]`로, 식단 수정 페이지는 후에 `viewPlan/edit/[id]`로 폴더 위치 변경할 예정입니다!
2. 식단 상세 페이지 - 기존처럼 Input에 식단 제목을 넣는 것은 어울리지 않는 것 같아 페이지 제목 대신 식단 제목을 넣어보았습니다. 한 번 보시고 의견주시면 감사하겠습니다~
3. 식단 상세 페이지 - 와이어프레임에선 설문 생성 버튼도 있던데, 이 버튼이 없어도 navbar에서 바로 식단 생성을 할 수 있기에 필요없다고 생각되어 넣지 않았습니다.

