### PR TITLE
Feat[#THKV-61] : API end point 및 param명 객체화, menu 및 menucategory API 타입정의

### DIFF
--- a/src/constants/_apiPath.ts
+++ b/src/constants/_apiPath.ts
@@ -1,0 +1,61 @@
+/**
+ * @description base API endpoints
+ */
+export const BASE_API = {
+  AUTHS: '/auths',
+  SURVEYS: '/surveys',
+  MONTH_MENUS: '/month-menus',
+  MENU_CATEGORIES: '/menu-categories',
+  USERS: '/users',
+};
+
+/**
+ * @description auth API endpoints
+ */
+export const AUTH_API = {
+  SIGNUP: `${BASE_API.AUTHS}/signup`,
+  SEND: `${BASE_API.AUTHS}/send`,
+  VERIFY: `${BASE_API.AUTHS}/verify`,
+  LOGIN: `${BASE_API.AUTHS}/login`,
+  REISSUE: `${BASE_API.AUTHS}/reissue`,
+  LOGOUT: `${BASE_API.AUTHS}/logout`,
+};
+
+/**
+ * @description 설문(survey) API endpoints, param
+ */
+export const SURVEY_API = {
+  SURVEYS: BASE_API.SURVEYS,
+  SORT: 'sort',
+  RESPONSES: '/responses',
+};
+
+/**
+ * @description  식단(menu) API endpoints, param
+ */
+export const MENUS_API = {
+  MONTH_MENUS: BASE_API.MONTH_MENUS,
+  AUTO: `${BASE_API.MONTH_MENUS}/auto`,
+  SAVE: `${BASE_API.MONTH_MENUS}/save`,
+  FOODS: `${BASE_API.MONTH_MENUS}/foods`,
+  FOOD_NAME: 'foodName',
+  COUNT: 'count',
+};
+
+/**
+ * @description 메뉴 카테고리 API endpoints, param
+ */
+export const MENU_CAGEGORY_API = {
+  MENU_CATEGORIES: BASE_API.MENU_CATEGORIES,
+  MAJOR_CATEGORY: 'major-category',
+  MINOR_CATEGORY: 'minor-category',
+};
+
+/**
+ * @description user API endpoints
+ */
+export const USER_API = {
+  USERS: BASE_API.USERS,
+  CHECK_PW: `${BASE_API.USERS}/check-pw`,
+  EDIT_PW: `${BASE_API.USERS}/edit-pw`,
+};

--- a/src/type/menu/menuRequest.ts
+++ b/src/type/menu/menuRequest.ts
@@ -1,0 +1,70 @@
+/**
+ * @description 병원 식단 소분류 카테고리
+ */
+export type HospitalMinorCategory =
+  | '연하3단계죽'
+  | '당뇨연식1800Kcal'
+  | '고단백연식'
+  | '고단백식'
+  | '당뇨상식1800Kcal'
+  | '전체'
+  | '당뇨상식1400Kcal'
+  | '혈투연식'
+  | '고단백상식'
+  | '신부전상식'
+  | '간성혼수상식'
+  | '당뇨상식2200Kcal'
+  | '일반연식'
+  | '당뇨연식2100Kcal'
+  | '저염연식'
+  | '일반상식'
+  | '위절제상식'
+  | '당뇨연식1400Kcal'
+  | '당뇨상식2100Kcal'
+  | '저지방상식'
+  | '저염식'
+  | '당뇨연식2200Kcal'
+  | '상식'
+  | '선택식'
+  | '저염상식'
+  | '혈투상식'
+  | '신부전연식';
+
+/**
+ * @description 식단 대분류 카테고리
+ */
+export type MajorCategory = '학교' | '병원';
+
+/**
+ * @description 자동 식단 생성 request body
+ */
+export interface MonthMenusAutoRequest {
+  majorCategory: MajorCategory;
+  minorCategory: HospitalMinorCategory;
+  dayCount: number;
+}
+
+/**
+ * @description 병원 하루 식단
+ */
+export interface HospitalAutoDayMenus {
+  hospitalMenuId: string | null;
+  menuDate: string; // '2024-09-25'
+  food1: string;
+  food2: string;
+  food3: string;
+  food4: string;
+  food5: string;
+  food6: string;
+  food7: string;
+}
+
+/**
+ * @description 식단 저장, 수정 request body
+ */
+export interface MonthMenusSaveRequest {
+  monthMenuName: string;
+  majorCategory: MajorCategory;
+  minorCategory: HospitalMinorCategory;
+  monthMenusSaveList: HospitalAutoDayMenus[];
+}

--- a/src/type/menu/menuResponse.ts
+++ b/src/type/menu/menuResponse.ts
@@ -1,0 +1,96 @@
+import { HospitalMinorCategory, MajorCategory } from '@/type/menu/menuRequest';
+
+/**
+ * @description 음식 하나의 정보
+ */
+export interface FoodInfo {
+  foodId: string;
+  foodName: string;
+  carbohydrate: string;
+  protein: string;
+  fat: string;
+  kcal: string;
+}
+
+/**
+ * @description 병원 하루치 식단
+ */
+export interface HospitalMenu {
+  hospitalMenuId: string;
+  hospitalMenuKind: HospitalMinorCategory;
+  foods: FoodInfo[];
+}
+
+/**
+ * @description 자동 식단 생성 response body
+ */
+export interface MonthMenusAutoResponse {
+  message: string;
+  data: HospitalMenu[];
+}
+
+/**
+ * @description 식단 저장, 삭제 response body
+ */
+export interface MonthMenusSaveResponse {
+  message: string;
+  data: null;
+}
+
+export interface MenuResponseDTO {
+  userId: number;
+  monthMenuId: string;
+  majorCategory: MajorCategory;
+  //   TODO: 학교 minorCategory도 유니온으로 추가 필요
+  minorCategory: HospitalMinorCategory;
+  monthMenuName: string;
+  createAt: string;
+  //   TODO: 정확한 값으로 수정 필요. postman에서 빈 배열로 확인됨
+  monthMenuList: string[] | HospitalMonthMenu[];
+}
+
+export interface MonthMenusResponseData {
+  currentPage: number;
+  totalPages: number;
+  totalElements: number;
+  pageSize: number;
+  menuResponseDTOList: MenuResponseDTO[];
+}
+
+/**
+ * @description 식단 전체 조회 response body
+ */
+export interface MonthMenusResponse {
+  message: string;
+  data: MonthMenusResponseData;
+}
+
+export interface HospitalMonthMenu {
+  menuDate: string;
+  hospitalMenuId: string;
+  foodList: FoodInfo[];
+}
+
+/**
+ * @description 식단 상세 조회, 수정 response body
+ */
+export interface MonthMenusDetailResponse {
+  message: string;
+  data: MenuResponseDTO;
+}
+
+/**
+ * @description 음식 검색 response body
+ */
+export interface MonthMenusSearchResponse {
+  message: string;
+  data: FoodInfo[];
+}
+
+/**
+ * @description 식단 개수 조회 response body
+ */
+export interface MonthMenusCountResponse {
+  message: string;
+  data: FoodInfo[];
+}

--- a/src/type/menu/menuResponse.ts
+++ b/src/type/menu/menuResponse.ts
@@ -2,6 +2,7 @@ import { HospitalMinorCategory, MajorCategory } from '@/type/menu/menuRequest';
 
 /**
  * @description 음식 하나의 정보
+ * 음식 검색 response body
  */
 export interface FoodInfo {
   foodId: string;
@@ -14,6 +15,7 @@ export interface FoodInfo {
 
 /**
  * @description 병원 하루치 식단
+ * 자동 식단 생성, 식단 개수 조회 response body
  */
 export interface HospitalMenu {
   hospitalMenuId: string;
@@ -22,21 +24,8 @@ export interface HospitalMenu {
 }
 
 /**
- * @description 자동 식단 생성 response body
+ * @description 식단 상세 조회, 수정 response body
  */
-export interface MonthMenusAutoResponse {
-  message: string;
-  data: HospitalMenu[];
-}
-
-/**
- * @description 식단 저장, 삭제 response body
- */
-export interface MonthMenusSaveResponse {
-  message: string;
-  data: null;
-}
-
 export interface MenuResponseDTO {
   userId: number;
   monthMenuId: string;
@@ -49,7 +38,10 @@ export interface MenuResponseDTO {
   monthMenuList: string[] | HospitalMonthMenu[];
 }
 
-export interface MonthMenusResponseData {
+/**
+ * @description 식단 전체 조회 response body
+ */
+export interface MonthMenusResponse {
   currentPage: number;
   totalPages: number;
   totalElements: number;
@@ -57,40 +49,8 @@ export interface MonthMenusResponseData {
   menuResponseDTOList: MenuResponseDTO[];
 }
 
-/**
- * @description 식단 전체 조회 response body
- */
-export interface MonthMenusResponse {
-  message: string;
-  data: MonthMenusResponseData;
-}
-
 export interface HospitalMonthMenu {
   menuDate: string;
   hospitalMenuId: string;
   foodList: FoodInfo[];
-}
-
-/**
- * @description 식단 상세 조회, 수정 response body
- */
-export interface MonthMenusDetailResponse {
-  message: string;
-  data: MenuResponseDTO;
-}
-
-/**
- * @description 음식 검색 response body
- */
-export interface MonthMenusSearchResponse {
-  message: string;
-  data: FoodInfo[];
-}
-
-/**
- * @description 식단 개수 조회 response body
- */
-export interface MonthMenusCountResponse {
-  message: string;
-  data: FoodInfo[];
 }

--- a/src/type/menuCategory/menuCategoryResponse.ts
+++ b/src/type/menuCategory/menuCategoryResponse.ts
@@ -1,25 +1,12 @@
 import { MenuResponseDTO } from '@/type/menu/menuResponse';
 
 /**
- * @description 소분류 목록 조회 response body
+ * @description 카테고리로 식단 전체 목록 조회 response body
  */
-export interface MenuMinorCategoryResponse {
-  message: string;
-  data: string[];
-}
-
-export interface MenuListByCategoriesResponseData {
+export interface MenuListByCategoriesResponse {
   currentPage: number;
   totalPages: number;
   totalElements: number;
   pageSize: number;
   menuResponseDTOList: MenuResponseDTO[];
-}
-
-/**
- * @description 카테고리로 식단 전체 목록 조회 response body
- */
-export interface MenuListByCategoriesResponse {
-  message: string;
-  data: MenuListByCategoriesResponseData;
 }

--- a/src/type/menuCategory/menuCategoryResponse.ts
+++ b/src/type/menuCategory/menuCategoryResponse.ts
@@ -1,0 +1,25 @@
+import { MenuResponseDTO } from '@/type/menu/menuResponse';
+
+/**
+ * @description 소분류 목록 조회 response body
+ */
+export interface MenuMinorCategoryResponse {
+  message: string;
+  data: string[];
+}
+
+export interface MenuListByCategoriesResponseData {
+  currentPage: number;
+  totalPages: number;
+  totalElements: number;
+  pageSize: number;
+  menuResponseDTOList: MenuResponseDTO[];
+}
+
+/**
+ * @description 카테고리로 식단 전체 목록 조회 response body
+ */
+export interface MenuListByCategoriesResponse {
+  message: string;
+  data: MenuListByCategoriesResponseData;
+}


### PR DESCRIPTION
<!--
제목은 `feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) feat[#Issue number]: 기능 구현
-->

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- API end point 및 param명 객체화
- menu 및 menucategory API 타입정의

### 설명 (선택)
- 원래는 자동식단생성부터 api 연결 시도해보려고 헀는데, BE에서 스프링배치 이슈로 아직 식단 데이터를 받아볼 수 없다고 하여 먼저 할 수 있는 것들부터 하였습니다.
1. API 엔드 포인트랑 파람명들 객체 변수로 분리하였습니다. 승현님 쪽에서도 가져다가 사용하시면 좋을 것 같습니다.
2. 식단 페이지에서 사용되는 API의 request, response 타입 정의했습니다. 

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
1. API 타입 정의
-  저는 아래와 같은 기준 사용하여 타입명 지었는데, 승현님도 괜찮으시면 저랑 통일하시면 좋을 것 같습니다~
```tsx
// 타입명 : api 엔드포인트 카멜케이스로 연결. request body면 Request 접미사 사용, response body면 Response 사용.
// 마땅한 엔드포인트 없을 시에는 타입 최대한 잘 나타내는 이름 사용
// data 키에 들어가는 타입이면 Data 접미사 사용

// ex) 식단 전체 조회 response body 타입은 MonthMenusResponse. data 키에는 MonthMenusResponseData 사용
export interface MonthMenusResponseData {
  currentPage: number;
  totalPages: number;
  totalElements: number;
  pageSize: number;
  menuResponseDTOList: MenuResponseDTO[];
}

/**
 * @description 식단 전체 조회 response body
 */
export interface MonthMenusResponse {
  message: string;
  data: MonthMenusResponseData;
}

```
- TS docs 사용해서 최대한 타입 잘 파악할 수 있게 적어보았습니다. 한 번 보시고 피드백 부탁드립니다~

2. 분량이 짧으니 가능하면 45번 PR 보다 먼저 머지되어서, 승현님도 엔드포인트 객체 가져다 쓰시면 어떨까 싶습니다~ 의견 남겨주십쇼~