### PR TITLE
Feat[THKV-64]: 설문생성 api 연결

### DIFF
--- a/src/api/survey/index.ts
+++ b/src/api/survey/index.ts
@@ -1,6 +1,10 @@
-import { get } from '@/lib/axios';
+import { get, post } from '@/lib/axios';
 import { Result } from '@/type/response';
-import { SurveyListResponse } from '@/type/survey/surveyResponse';
+import { PostSurveyRequest } from '@/type/survey/surveyRequest';
+import {
+  SurveyListResponse,
+  SurveyPostResponse,
+} from '@/type/survey/surveyResponse';
 import { SURVEY_API } from '@/constants/_apiPath';
 
 const getSurveyList = async () => {
@@ -8,6 +12,15 @@ const getSurveyList = async () => {
   return response.data;
 };
 
+const postSurvey = async (request: PostSurveyRequest) => {
+  const response = await post<Result<SurveyPostResponse>>(
+    SURVEY_API.SURVEYS,
+    request,
+  );
+  return response.data;
+};
+
 export const survey = {
   getSurveyList,
+  postSurvey,
 };

--- a/src/hooks/survey/usePostSurvey.ts
+++ b/src/hooks/survey/usePostSurvey.ts
@@ -1,0 +1,23 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { survey } from '@/api/survey';
+import { Result } from '@/type/response';
+import { PostSurveyRequest } from '@/type/survey/surveyRequest';
+import { SurveyPostResponse } from '@/type/survey/surveyResponse';
+
+export const usePostSurvey = (
+  options?: UseMutationOptions<
+    Result<SurveyPostResponse>,
+    AxiosError<Result<SurveyPostResponse>>,
+    PostSurveyRequest
+  >,
+) => {
+  return useMutation<
+    Result<SurveyPostResponse>,
+    AxiosError<Result<SurveyPostResponse>>,
+    PostSurveyRequest
+  >({
+    mutationFn: (request) => survey.postSurvey(request),
+    ...options,
+  });
+};

--- a/src/type/survey/surveyRequest.ts
+++ b/src/type/survey/surveyRequest.ts
@@ -1,0 +1,8 @@
+import { inputsType } from '@/components/feature/Survey/Create';
+
+export interface PostSurveyRequest {
+  mmId: string;
+  surveyName: string;
+  deadlineAt: Date | null;
+  additionalQuestions: inputsType[];
+}

--- a/src/type/survey/surveyResponse.ts
+++ b/src/type/survey/surveyResponse.ts
@@ -1,3 +1,5 @@
+import { inputsType } from '@/components/feature/Survey/Create';
+
 export interface SurveyListResponse {
   totalItems: number;
   currentPage: number;
@@ -9,4 +11,12 @@ export interface SurveyListResponse {
     deadlineAt?: string;
     state?: string;
   }[];
+}
+
+export interface SurveyPostResponse {
+  surveyId: number;
+  mmId: string;
+  createdAt: Date | null;
+  deadlineAt: Date | null;
+  questions: inputsType[];
 }


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 설문 생성 페이지에서 설문생성 api연결

### 설명 (선택)

- 설문 생성페이지에서 입력한 제목, 마감날짜, 추가질문을 받아서 그에따라 설문을 생성하는 기능 구현

## 스크린샷

## 리뷰 요구사항

- mmId는 추후에 /viewPlan/[mmId]로 변경 후에 가져와서 사용할 예정입니다 (현재는 정적 값)
