### PR TITLE
Feat[#THKV-85]: 설문 QR코드 구현

### DIFF
--- a/src/api/survey/index.ts
+++ b/src/api/survey/index.ts
@@ -1,12 +1,16 @@
 import { get, post, del, put } from '@/lib/axios';
+import { env } from '@/lib/env';
 import { Result } from '@/type/response';
 import {
   GetSearchSurveyRequest,
+  PostServeyQrCodeRequest,
   PostServeyResponsesRequest,
   PostSurveyRequest,
   PutSurveyRequest,
 } from '@/type/survey/surveyRequest';
 import {
+  GetSurveyQrCodeResponse,
+  PostSurveyQrCodeResponse,
   PostSurveyResponsesResponse,
   PutSurveyResponse,
   SurveyDetailResponse,
@@ -72,6 +76,21 @@ const postResponses = async (
   return response.data;
 };
 
+const postSurveyQrCode = async (reqeust: PostServeyQrCodeRequest) => {
+  const response = await post<Result<PostSurveyQrCodeResponse>>(
+    `${env.QR_API_URL}/${env.QR_APP_KEY}/urls`,
+    reqeust,
+  );
+  return response.data;
+};
+
+const getSurveyQrCode = async (id: number) => {
+  const response = await get<GetSurveyQrCodeResponse>(
+    `${env.QR_API_URL}/${env.QR_APP_KEY}/domains/nh.nu/urls/${id}/qrcode`,
+  );
+  return response.data;
+};
+
 export const survey = {
   getSurveyList,
   postSurvey,
@@ -79,4 +98,6 @@ export const survey = {
   getSurveyDetail,
   putSurvey,
   postResponses,
+  postSurveyQrCode,
+  getSurveyQrCode,
 };

--- a/src/api/survey/index.ts
+++ b/src/api/survey/index.ts
@@ -2,10 +2,12 @@ import { get, post, del, put } from '@/lib/axios';
 import { Result } from '@/type/response';
 import {
   GetSearchSurveyRequest,
+  PostServeyResponsesRequest,
   PostSurveyRequest,
   PutSurveyRequest,
 } from '@/type/survey/surveyRequest';
 import {
+  PostSurveyResponsesResponse,
   PutSurveyResponse,
   SurveyDetailResponse,
   SurveyListResponse,
@@ -59,10 +61,22 @@ const putSurvey = async (id: number, request: PutSurveyRequest) => {
   return response.data;
 };
 
+const postResponses = async (
+  id: number,
+  request: PostServeyResponsesRequest,
+) => {
+  const response = await post<Result<PostSurveyResponsesResponse>>(
+    `${SURVEY_API.SURVEYS}/${id}${SURVEY_API.RESPONSES}`,
+    request,
+  );
+  return response.data;
+};
+
 export const survey = {
   getSurveyList,
   postSurvey,
   deleteSurvey,
   getSurveyDetail,
   putSurvey,
+  postResponses,
 };

--- a/src/app/(root)/survey/create/[id]/page.tsx
+++ b/src/app/(root)/survey/create/[id]/page.tsx
@@ -1,0 +1,8 @@
+import SurveyCreate from '@/components/feature/Survey/Create';
+
+const page = ({ params }: { params: { id: string } }) => {
+  const { id } = params;
+  return <SurveyCreate id={id} />;
+};
+
+export default page;

--- a/src/app/(root)/survey/create/page.tsx
+++ b/src/app/(root)/survey/create/page.tsx
@@ -1,7 +1,0 @@
-import SurveyCreate from '@/components/feature/Survey/Create';
-
-const page = () => {
-  return <SurveyCreate />;
-};
-
-export default page;

--- a/src/components/feature/ChartDetail/index.tsx
+++ b/src/components/feature/ChartDetail/index.tsx
@@ -21,18 +21,13 @@ import { NAV_LINKS, ROUTES } from '@/constants/_navbar';
 import { surveyKeys } from '@/hooks/survey/queryKey';
 import { useDeleteSurvey } from '@/hooks/survey/useDeleteSurvey';
 import { useGetSurveyDetail } from '@/hooks/survey/useGetSurveyDetail';
+import { useGetSurveyQrCode } from '@/hooks/survey/useGetSurveyQrCode';
 import useNavigate from '@/hooks/useNavigate';
 import { useToastStore } from '@/stores/useToastStore';
 
 interface Props {
   id: number;
 }
-
-// TODO: qr코드 api완성 후 삭제예정
-const imageInfo = {
-  size: 180,
-  src: '/imgs/pi-gon-ping.jpg',
-};
 
 const ChartDetail = ({ id }: Props) => {
   const router = useRouter();
@@ -54,6 +49,10 @@ const ChartDetail = ({ id }: Props) => {
 
   const { data: detailData } = useGetSurveyDetail(id);
 
+  const { data: qrData } = useGetSurveyQrCode(id, {
+    enabled: !!detailData,
+  });
+
   const { surveyName, averageScores, additionalQuestions, mandatoryQuestions } =
     detailData || {};
 
@@ -71,7 +70,8 @@ const ChartDetail = ({ id }: Props) => {
       {detailData &&
         averageScores &&
         mandatoryQuestions &&
-        additionalQuestions && (
+        additionalQuestions &&
+        qrData && (
           <>
             <div className='flex items-center justify-between'>
               <PageHeaderTitle>{surveyName}</PageHeaderTitle>
@@ -128,9 +128,9 @@ const ChartDetail = ({ id }: Props) => {
                   <CardTitle>설문 조사 링크</CardTitle>
                   <div className='flex items-center justify-center'>
                     <Image
-                      src={imageInfo.src}
-                      width={imageInfo.size}
-                      height={imageInfo.size}
+                      width={180}
+                      height={180}
+                      src={`data:image/png;base64,${qrData.body}`}
                       alt='qr이미지'
                     />
                   </div>

--- a/src/components/feature/ChartDetail/index.tsx
+++ b/src/components/feature/ChartDetail/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { FailResponse } from '@/type/response';
-import { SatisfactionDistributionItem } from '@/type/survey/surveyResponse';
+import { Question } from '@/type/survey/surveyResponse';
 import { getTextResponsesByQuestionText } from '@/utils/getTextResponseByQuestionText';
 import Button from '@/components/common/Button/Button';
 import {
@@ -54,116 +54,113 @@ const ChartDetail = ({ id }: Props) => {
 
   const { data: detailData } = useGetSurveyDetail(id);
 
-  const { surveyName, averageScores, satisfactionDistributions } =
+  const { surveyName, averageScores, additionalQuestions, mandatoryQuestions } =
     detailData || {};
 
   const deleteHandler = () => {
     deleteSurveyMutate(id);
   };
 
-  const isAllDistributionZero = (
-    distribution: SatisfactionDistributionItem,
-  ) => {
-    const distributionValues = Object.values(
-      distribution.satisfactionDistribution,
-    );
+  const isAllDistributionZero = (distribution: Question) => {
+    const distributionValues = Object.values(distribution.radioResponses);
     return distributionValues.every((value) => value === 0);
   };
 
   return (
     <div className='flex flex-col gap-10'>
-      {detailData && satisfactionDistributions && averageScores && (
-        <>
-          <div className='flex items-center justify-between'>
-            <PageHeaderTitle>{surveyName}</PageHeaderTitle>
-            <div className='flex h-8 gap-3'>
-              <Button size='small'>설문 종료</Button>
-              <Button
-                size='small'
-                onClick={() => navigate(`${ROUTES.SURVEY.EDIT}/${id}`)}
-              >
-                질문 수정
-              </Button>
-              <Button size='small' onClick={deleteHandler}>
-                설문 삭제
-              </Button>
-            </div>
-          </div>
-          <div className='flex w-full gap-5'>
-            <div className='flex w-full flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
-              <CardTitle>월별 총 만족도 점수 분포도</CardTitle>
-              {satisfactionDistributions.every(isAllDistributionZero) ? (
-                <HeadPrimary>제출된 설문이 없습니다.</HeadPrimary>
-              ) : (
-                <BarGraph
-                  data={satisfactionDistributions[0].satisfactionDistribution}
-                />
-              )}
-            </div>
-            <div className='flex w-1/2 flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
-              <CardTitle>만족도 평균</CardTitle>
-              {!Object.values(averageScores).every((score) => score === 0) ? (
-                <AverageGraph averageScores={averageScores} />
-              ) : (
-                <HeadPrimary>제출된 설문이 없습니다.</HeadPrimary>
-              )}
-            </div>
-          </div>
-          <div className='flex w-full gap-8'>
-            <div className='flex w-full flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
-              <TopCard
-                title='식단 좋아요 Top3'
-                top3Data={getTextResponsesByQuestionText(
-                  satisfactionDistributions,
-                  '가장 좋아하는 상위 3개 식단',
-                )}
-              />
-              <TopCard
-                title='식단 싫어요 Top3'
-                top3Data={getTextResponsesByQuestionText(
-                  satisfactionDistributions,
-                  '가장 싫어하는 상위 3개 식단',
-                )}
-              />
-            </div>
-            <div className='flex w-1/3 flex-col gap-3'>
-              <div className='mb-3 flex flex-1 flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
-                <CardTitle>설문 조사 링크</CardTitle>
-                <div className='flex items-center justify-center'>
-                  <Image
-                    src={imageInfo.src}
-                    width={imageInfo.size}
-                    height={imageInfo.size}
-                    alt='qr이미지'
-                  />
-                </div>
+      {detailData &&
+        averageScores &&
+        mandatoryQuestions &&
+        additionalQuestions && (
+          <>
+            <div className='flex items-center justify-between'>
+              <PageHeaderTitle>{surveyName}</PageHeaderTitle>
+              <div className='flex h-8 gap-3'>
+                <Button size='small'>설문 종료</Button>
+                <Button
+                  size='small'
+                  onClick={() => navigate(`${ROUTES.SURVEY.EDIT}/${id}`)}
+                >
+                  질문 수정
+                </Button>
+                <Button size='small' onClick={deleteHandler}>
+                  설문 삭제
+                </Button>
               </div>
-              <TextList
-                type='desireMenu'
-                list={
-                  getTextResponsesByQuestionText(
-                    satisfactionDistributions,
-                    '먹고 싶은 메뉴',
-                  )!
-                }
-                title='먹고 싶은 메뉴 목록'
-              />
             </div>
-            <div className='flex w-2/3 flex-col gap-3'>
-              <TextList
-                type='message'
-                list={
-                  getTextResponsesByQuestionText(
-                    satisfactionDistributions,
-                    '영양사에게 한마디',
-                  )!
-                }
-                title='영양사에게 한마디'
-              />
+            <div className='flex w-full gap-5'>
+              <div className='flex w-full flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
+                <CardTitle>월별 총 만족도 점수 분포도</CardTitle>
+                {mandatoryQuestions!.every(isAllDistributionZero) ? (
+                  <HeadPrimary>제출된 설문이 없습니다.</HeadPrimary>
+                ) : (
+                  <BarGraph data={mandatoryQuestions![0].radioResponses} />
+                )}
+              </div>
+              <div className='flex w-1/2 flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
+                <CardTitle>만족도 평균</CardTitle>
+                {!Object.values(averageScores).every((score) => score === 0) ? (
+                  <AverageGraph averageScores={averageScores} />
+                ) : (
+                  <HeadPrimary>제출된 설문이 없습니다.</HeadPrimary>
+                )}
+              </div>
             </div>
-          </div>
-        </>
-      )}
+            <div className='flex w-full gap-8'>
+              <div className='flex w-full flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
+                <TopCard
+                  title='식단 좋아요 Top3'
+                  top3Data={getTextResponsesByQuestionText(
+                    mandatoryQuestions,
+                    '가장 좋아하는 상위 3개 식단',
+                  )}
+                />
+                <TopCard
+                  title='식단 싫어요 Top3'
+                  top3Data={getTextResponsesByQuestionText(
+                    mandatoryQuestions,
+                    '가장 싫어하는 상위 3개 식단',
+                  )}
+                />
+              </div>
+              <div className='flex w-1/3 flex-col gap-3'>
+                <div className='mb-3 flex flex-1 flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
+                  <CardTitle>설문 조사 링크</CardTitle>
+                  <div className='flex items-center justify-center'>
+                    <Image
+                      src={imageInfo.src}
+                      width={imageInfo.size}
+                      height={imageInfo.size}
+                      alt='qr이미지'
+                    />
+                  </div>
+                </div>
+                <TextList
+                  type='desireMenu'
+                  list={
+                    getTextResponsesByQuestionText(
+                      mandatoryQuestions,
+                      '먹고 싶은 메뉴',
+                    )!
+                  }
+                  title='먹고 싶은 메뉴 목록'
+                />
+              </div>
+              <div className='flex w-2/3 flex-col gap-3'>
+                <TextList
+                  type='message'
+                  list={
+                    getTextResponsesByQuestionText(
+                      mandatoryQuestions,
+                      '영양사에게 한마디',
+                    )!
+                  }
+                  title='영양사에게 한마디'
+                />
+              </div>
+            </div>
+          </>
+        )}
     </div>
   );
 };

--- a/src/components/feature/Survey/Create/index.tsx
+++ b/src/components/feature/Survey/Create/index.tsx
@@ -19,7 +19,6 @@ import { useToastStore } from '@/stores/useToastStore';
 import 'react-datepicker/dist/react-datepicker.css';
 import '@/styles/datepicker-custom.css';
 
-const EXTRA_SURVEYNAME_LIMIT = 30;
 const TWO_WEEK_DAYS = 14;
 const { now: twoWeeksLater } = getCurrentYearMonthNow();
 twoWeeksLater.setDate(twoWeeksLater.getDate() + TWO_WEEK_DAYS);
@@ -45,12 +44,6 @@ const SurveyCreate = ({ id }: { id: string }) => {
     surveyName: surveyName,
     deadlineAt: deadLine,
     additionalQuestions: inputs,
-  };
-
-  const handleSurveyNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.value.length <= EXTRA_SURVEYNAME_LIMIT) {
-      setSurveyName(e.target.value);
-    }
   };
 
   const submitSurvey = () => {
@@ -81,7 +74,7 @@ const SurveyCreate = ({ id }: { id: string }) => {
       <SurveyControls
         type='create'
         surveyName={surveyName}
-        handleSurveyNameChange={handleSurveyNameChange}
+        setSurveyName={setSurveyName}
         deadLine={deadLine}
         setDeadLine={setDeadLine}
       />

--- a/src/components/feature/Survey/Create/index.tsx
+++ b/src/components/feature/Survey/Create/index.tsx
@@ -5,7 +5,10 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 import { FailResponse, Result } from '@/type/response';
-import { SurveyPostResponse } from '@/type/survey/surveyResponse';
+import {
+  PostSurveyQrCodeResponse,
+  SurveyPostResponse,
+} from '@/type/survey/surveyResponse';
 import { getCurrentYearMonthNow } from '@/utils/calendar';
 import AdditionQuestions from '@/components/shared/Survey/AdditionQuestions';
 import SurveyControls from '@/components/shared/Survey/Controls';
@@ -15,6 +18,7 @@ import { NAV_LINKS } from '@/constants/_navbar';
 import { WARNING } from '@/constants/_toastMessage';
 import { surveyKeys } from '@/hooks/survey/queryKey';
 import { usePostSurvey } from '@/hooks/survey/usePostSurvey';
+import { usePostSurveyQrCode } from '@/hooks/survey/usePostSurveyQrCode';
 import { useToastStore } from '@/stores/useToastStore';
 import 'react-datepicker/dist/react-datepicker.css';
 import '@/styles/datepicker-custom.css';
@@ -34,6 +38,8 @@ const SurveyCreate = ({ id }: { id: string }) => {
   const router = useRouter();
   const { mutate: postSurveyMutate, isSuccess: postSurveySuccess } =
     usePostSurvey();
+  const { mutate: postSurveyQrCodeMutate } = usePostSurveyQrCode();
+
   const [inputs, setInputs] = useState<inputsType[]>([]);
   const [surveyName, setSurveyName] = useState('');
   const [deadLine, setDeadLine] = useState<Date | null>(twoWeeksLater);
@@ -51,11 +57,30 @@ const SurveyCreate = ({ id }: { id: string }) => {
       showToast(WARNING.requiredSurveyName, 'warning', 2000);
       return;
     }
+
     postSurveyMutate(requestData, {
-      onSuccess: ({ message }: Result<SurveyPostResponse>) => {
+      onSuccess: ({ message, data }: Result<SurveyPostResponse>) => {
         showToast(message, 'success', 1000);
         queryClient.invalidateQueries({ queryKey: surveyKeys.search() });
         router.replace(NAV_LINKS[4].href);
+        postSurveyQrCodeMutate(
+          {
+            // TODO: 배포된 설문응답 url로 이동시켜야함.
+            // url: `http://localhost:3000/survey/take/${data.surveyId}`,
+            url: 'https://www.naver.com',
+            backHalf: data.surveyId,
+          },
+          {
+            onSuccess: ({ message }: Result<PostSurveyQrCodeResponse>) => {
+              showToast(message, 'success', 1000);
+            },
+            onError: (error: AxiosError<FailResponse>) => {
+              const errorMessage =
+                error.response?.data.message || 'QR코드 생성 실패';
+              showToast(errorMessage, 'warning', 1000);
+            },
+          },
+        );
       },
       onError: (error: AxiosError<FailResponse>) => {
         const errorMessage = error.response?.data?.message || '설문 생성 실패';

--- a/src/components/feature/Survey/Create/index.tsx
+++ b/src/components/feature/Survey/Create/index.tsx
@@ -30,7 +30,7 @@ export interface inputsType {
   answerType: string;
 }
 
-const SurveyCreate = () => {
+const SurveyCreate = ({ id }: { id: string }) => {
   const queryClient = useQueryClient();
   const router = useRouter();
   const { mutate: postSurveyMutate, isSuccess: postSurveySuccess } =
@@ -41,8 +41,7 @@ const SurveyCreate = () => {
   const showToast = useToastStore((state) => state.showToast);
 
   const requestData = {
-    // TODO: mmId searchParam으로 가져온 값으로 수정예정
-    mmId: '8ebee81d-de92-4c40-bd42-52e95138e94d',
+    mmId: id,
     surveyName: surveyName,
     deadlineAt: deadLine,
     additionalQuestions: inputs,

--- a/src/components/feature/Survey/Edit/index.tsx
+++ b/src/components/feature/Survey/Edit/index.tsx
@@ -89,7 +89,7 @@ const SurveyEdit = ({ id }: Props) => {
           <AdditionQuestions
             inputs={inputs}
             setInputs={setInputs}
-            successSubmit={false}
+            successSubmit={true}
           />
         </div>
       </div>

--- a/src/components/feature/Survey/Take/index.tsx
+++ b/src/components/feature/Survey/Take/index.tsx
@@ -53,21 +53,21 @@ const SurveyTake = ({ id }: Props) => {
   };
 
   const submitSurvey = () => {
+    const formattedBasicAnswers = Object.entries(answers)
+      .slice(0, 8)
+      .map(([questionId, answer]) => ({
+        questionId: Number(questionId),
+        answer,
+      }));
+    const formattedAdditionalAnswers = Object.entries(answers)
+      .slice(8)
+      .map(([questionId, answer]) => ({
+        questionId: Number(questionId),
+        answer,
+      }));
     mutate({
-      basicQuestions: [
-        { questionId: 10, answer: 8 },
-        { questionId: 11, answer: 2 },
-        { questionId: 12, answer: 3 },
-        { questionId: 13, answer: 6 },
-        { questionId: 14, answer: ['test', 'test', 'test'] },
-        { questionId: 15, answer: ['test2', 'test2', 'test2'] },
-        { questionId: 16, answer: 'test3' },
-        { questionId: 17, answer: 'test4' },
-      ],
-      additionalQuestions: [
-        { questionId: 18, answer: 'test5' },
-        { questionId: 19, answer: 4 },
-      ],
+      basicQuestions: formattedBasicAnswers,
+      additionalQuestions: formattedAdditionalAnswers,
     });
   };
 
@@ -89,7 +89,7 @@ const SurveyTake = ({ id }: Props) => {
             1(매우 아니다) - 10(매우 그렇다)
           </span>
         </div>
-        {surveyData?.satisfactionDistributions.map((question, idx) => (
+        {surveyData?.mandatoryQuestions.map((question, idx) => (
           <div
             key={question.questionId}
             className='flex w-full flex-col gap-1 border-b border-gray-300 pb-3'
@@ -97,11 +97,45 @@ const SurveyTake = ({ id }: Props) => {
             <li className='flex items-center gap-1'>
               <span>{idx + 1}. </span>
               <span>{question.questionText}</span>
-              {/* <span
-                className={question.isMandatory ? 'text-red-200' : 'hidden'}
-              >
-                *
-              </span> */}
+            </li>
+            {question.answerType === 'text' && (
+              <Input
+                value={answers[question.questionId] || ''}
+                bgcolor='meal'
+                onChange={(e) =>
+                  handleChange(question.questionId, e.target.value)
+                }
+              />
+            )}
+            {question.answerType === 'radio' && (
+              <div className='flex justify-around'>
+                {RADIO_OPTIONS.map((option) => (
+                  <div key={option} className='flex gap-2'>
+                    <input
+                      type='radio'
+                      name={`question${question.questionId}`}
+                      id={`${question.questionId}_${option}`}
+                      value={option}
+                      checked={answers[question.questionId] === option}
+                      onChange={() => handleChange(question.questionId, option)}
+                    />
+                    <label htmlFor={`${question.questionId}_${option}`}>
+                      {option}
+                    </label>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+        {surveyData?.additionalQuestions.map((question, idx) => (
+          <div
+            key={question.questionId}
+            className='flex w-full flex-col gap-1 border-b border-gray-300 pb-3'
+          >
+            <li className='flex items-center gap-1'>
+              <span>{idx + 1}. </span>
+              <span>{question.questionText}</span>
             </li>
             {question.answerType === 'text' && (
               <Input

--- a/src/components/shared/Survey/AdditionQuestions/index.tsx
+++ b/src/components/shared/Survey/AdditionQuestions/index.tsx
@@ -95,7 +95,6 @@ const AdditionQuestions = ({ inputs, setInputs, successSubmit }: Props) => {
                 bgcolor='meal'
                 value={input.question}
                 onChange={(e) => handleChangeInput(e, idx)}
-                readOnly={successSubmit}
                 placeholder='추가 질문을 입력해주세요.'
               />
               <Selectbox

--- a/src/components/shared/Survey/Controls/index.tsx
+++ b/src/components/shared/Survey/Controls/index.tsx
@@ -10,15 +10,15 @@ import CustomDatePickerHeader from '@/components/shared/Survey/CustomDatePickerH
 interface Props {
   type: 'create' | 'edit';
   surveyName: string;
-  handleSurveyNameChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  setEditSurveyName: React.Dispatch<React.SetStateAction<string>>;
   deadLine: Date | null;
-  setDeadLine?: React.Dispatch<React.SetStateAction<Date | null>>;
+  setDeadLine: React.Dispatch<React.SetStateAction<Date | null>>;
 }
 
 const SurveyControls = ({
   type,
   surveyName,
-  handleSurveyNameChange,
+  setEditSurveyName,
   deadLine,
   setDeadLine,
 }: Props) => {
@@ -32,6 +32,10 @@ const SurveyControls = ({
     }
   };
 
+  const handleChangeSurveyName = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditSurveyName(e.target.value);
+  };
+
   const handleOpenDatePicker = () => {
     deadLineDatePickerRef.current!.setFocus();
   };
@@ -41,8 +45,7 @@ const SurveyControls = ({
       <div className='w-1/3'>
         <Input
           value={surveyName}
-          onChange={handleSurveyNameChange}
-          disabled={!isChangeable}
+          onChange={handleChangeSurveyName}
           placeholder='설문 이름을 입력하세요. (최대 30자)'
           className='font-semibold'
           bgcolor='meal'
@@ -56,7 +59,6 @@ const SurveyControls = ({
           className='flex w-28 cursor-pointer border-b border-green-400 bg-transparent pl-1 focus:outline-none disabled:cursor-not-allowed disabled:opacity-80'
           shouldCloseOnSelect
           dateFormat='yyyy-MM-dd'
-          disabled={!isChangeable}
           selected={deadLine}
           locale={ko}
           minDate={now}

--- a/src/components/shared/Survey/Controls/index.tsx
+++ b/src/components/shared/Survey/Controls/index.tsx
@@ -10,15 +10,19 @@ import CustomDatePickerHeader from '@/components/shared/Survey/CustomDatePickerH
 interface Props {
   type: 'create' | 'edit';
   surveyName: string;
-  setEditSurveyName: React.Dispatch<React.SetStateAction<string>>;
+  setEditSurveyName?: React.Dispatch<React.SetStateAction<string>>;
+  setSurveyName?: React.Dispatch<React.SetStateAction<string>>;
   deadLine: Date | null;
   setDeadLine: React.Dispatch<React.SetStateAction<Date | null>>;
 }
+
+const EXTRA_SURVEYNAME_LIMIT = 30;
 
 const SurveyControls = ({
   type,
   surveyName,
   setEditSurveyName,
+  setSurveyName,
   deadLine,
   setDeadLine,
 }: Props) => {
@@ -33,7 +37,12 @@ const SurveyControls = ({
   };
 
   const handleChangeSurveyName = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setEditSurveyName(e.target.value);
+    if (e.target.value.length <= EXTRA_SURVEYNAME_LIMIT && !isChangeable) {
+      setEditSurveyName!(e.target.value);
+    }
+    if (e.target.value.length <= EXTRA_SURVEYNAME_LIMIT && isChangeable) {
+      setSurveyName!(e.target.value);
+    }
   };
 
   const handleOpenDatePicker = () => {

--- a/src/components/shared/Survey/CustomDatePickerHeader/index.tsx
+++ b/src/components/shared/Survey/CustomDatePickerHeader/index.tsx
@@ -1,7 +1,7 @@
 import Icon from '@/components/common/Icon';
 
 interface Props {
-  date: Date;
+  date: Date | null;
   decreaseMonth: () => void;
   increaseMonth: () => void;
   prevMonthButtonDisabled: boolean;
@@ -24,9 +24,9 @@ const CustomDatePickerHeader = ({
       <Icon name='arrowPrev' width={20} color='active' />
     </button>
     <div className='text-base font-bold'>
-      {date.getFullYear()}
-      {'년 '}
-      {date.toLocaleString('default', { month: 'long' })}
+      {date instanceof Date && !isNaN(date.getTime())
+        ? `${date.getFullYear()}년 ${date.toLocaleString('default', { month: 'long' })}`
+        : '날짜 정보 없음'}
     </div>
     <button onClick={increaseMonth} disabled={nextMonthButtonDisabled}>
       <Icon name='arrowNext' width={20} color='active' />

--- a/src/hooks/survey/queryKey.ts
+++ b/src/hooks/survey/queryKey.ts
@@ -7,4 +7,5 @@ export const surveyKeys = {
   search: (request?: GetSearchSurveyRequest) =>
     [...surveyKeys.lists(), request] as const,
   detail: (surveyId: number) => [...surveyKeys.all, surveyId] as const,
+  qrCode: (id: number) => [...surveyKeys.all, id, 'qrCode'],
 };

--- a/src/hooks/survey/useGetSurveyQrCode.ts
+++ b/src/hooks/survey/useGetSurveyQrCode.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { survey } from '@/api/survey';
+import { surveyKeys } from './queryKey';
+
+export const useGetSurveyQrCode = (
+  id: number,
+  options?: {
+    enabled?: boolean;
+  },
+) => {
+  return useQuery({
+    queryKey: surveyKeys.qrCode(id),
+    queryFn: () => survey.getSurveyQrCode(id),
+    ...options,
+  });
+};

--- a/src/hooks/survey/usePostSurveyQrCode.ts
+++ b/src/hooks/survey/usePostSurveyQrCode.ts
@@ -1,0 +1,23 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { survey } from '@/api/survey';
+import { Result } from '@/type/response';
+import { PostServeyQrCodeRequest } from '@/type/survey/surveyRequest';
+import { PostSurveyQrCodeResponse } from '@/type/survey/surveyResponse';
+
+export const usePostSurveyQrCode = (
+  options?: UseMutationOptions<
+    Result<PostSurveyQrCodeResponse>,
+    AxiosError<Result<PostSurveyQrCodeResponse>>,
+    PostServeyQrCodeRequest
+  >,
+) => {
+  return useMutation<
+    Result<PostSurveyQrCodeResponse>,
+    AxiosError<Result<PostSurveyQrCodeResponse>>,
+    PostServeyQrCodeRequest
+  >({
+    mutationFn: (request) => survey.postSurveyQrCode(request),
+    ...options,
+  });
+};

--- a/src/hooks/survey/usePostSurveyResponses.ts
+++ b/src/hooks/survey/usePostSurveyResponses.ts
@@ -1,0 +1,24 @@
+import { useMutation, UseMutationOptions } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+import { survey } from '@/api/survey';
+import { Result } from '@/type/response';
+import { PostServeyResponsesRequest } from '@/type/survey/surveyRequest';
+import { PostSurveyResponsesResponse } from '@/type/survey/surveyResponse';
+
+export const usePostSurveyResponses = (
+  id: number,
+  options?: UseMutationOptions<
+    Result<PostSurveyResponsesResponse>,
+    AxiosError<Result<PostSurveyResponsesResponse>>,
+    PostServeyResponsesRequest
+  >,
+) => {
+  return useMutation<
+    Result<PostSurveyResponsesResponse>,
+    AxiosError<Result<PostSurveyResponsesResponse>>,
+    PostServeyResponsesRequest
+  >({
+    mutationFn: (request) => survey.postResponses(id, request),
+    ...options,
+  });
+};

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,3 +1,5 @@
 export const env = Object.freeze({
   BASE_API_URL: `${process.env.NEXT_PUBLIC_BASE_API_URL}`,
+  QR_API_URL: `${process.env.NEXT_PUBLIC_QR_API_URL}`,
+  QR_APP_KEY: `${process.env.NEXT_PUBLIC_QR_APPKEY}`,
 });

--- a/src/type/survey/surveyRequest.ts
+++ b/src/type/survey/surveyRequest.ts
@@ -18,10 +18,10 @@ export interface GetSearchSurveyRequest {
 }
 
 export interface PutSurveyRequest {
-  surveyName?: string;
-  deadlineAt?: string;
+  surveyName: string;
+  deadlineAt: Date | null;
   state?: string;
-  questions?: {
+  questions: {
     questionId: number;
     question: string;
     answerType: 'text' | 'radio';

--- a/src/type/survey/surveyRequest.ts
+++ b/src/type/survey/surveyRequest.ts
@@ -36,3 +36,8 @@ export interface PostServeyResponsesRequest {
   basicQuestions: questionsType[];
   additionalQuestions: questionsType[];
 }
+
+export interface PostServeyQrCodeRequest {
+  url: string;
+  backHalf: number;
+}

--- a/src/type/survey/surveyRequest.ts
+++ b/src/type/survey/surveyRequest.ts
@@ -27,3 +27,12 @@ export interface PutSurveyRequest {
     answerType: 'text' | 'radio';
   }[];
 }
+
+interface questionsType {
+  questionId: number;
+  answer: number | string | string[];
+}
+export interface PostServeyResponsesRequest {
+  basicQuestions: questionsType[];
+  additionalQuestions: questionsType[];
+}

--- a/src/type/survey/surveyResponse.ts
+++ b/src/type/survey/surveyResponse.ts
@@ -60,3 +60,29 @@ export interface PostSurveyResponsesResponse {
   responseId: number;
   surveyId: number;
 }
+
+export interface PostSurveyQrCodeResponse {
+  header: {
+    resultCode: number;
+    resultMessage: string;
+    isSuccessful: boolean;
+  };
+  body: {
+    shortUrl: string;
+    originUrl: string;
+    status: string;
+    backHalfType: string;
+    description: null;
+    startDateTime: Date;
+    endDateTime: Date;
+  };
+}
+
+export interface GetSurveyQrCodeResponse {
+  header: {
+    resultCode: number;
+    resultMessage: string;
+    isSuccessful: boolean;
+  };
+  body: string;
+}

--- a/src/type/survey/surveyResponse.ts
+++ b/src/type/survey/surveyResponse.ts
@@ -22,14 +22,18 @@ export interface SurveyPostResponse {
   questions: inputsType[];
 }
 
-export interface SatisfactionDistribution {
-  [key: string]: number;
+export interface SurveyDetailResponse {
+  surveyName: string;
+  deadline: Date | null;
+  mandatoryQuestions: Question[];
+  additionalQuestions: Question[];
+  averageScores: AverageScores;
 }
 
-export interface SatisfactionDistributionItem {
+export interface Question {
   questionId: number;
   questionText: string;
-  satisfactionDistribution: SatisfactionDistribution;
+  radioResponses: Record<string, number>;
   textResponses: string[];
   answerType: 'radio' | 'text';
 }
@@ -39,13 +43,6 @@ export interface AverageScores {
   portionSatisfaction: number;
   hygieneSatisfaction: number;
   tasteSatisfaction: number;
-}
-
-export interface SurveyDetailResponse {
-  surveyName: string;
-  satisfactionDistributions: SatisfactionDistributionItem[];
-  averageScores: AverageScores;
-  deadline: Date | null;
 }
 
 export interface PutSurveyResponse {

--- a/src/type/survey/surveyResponse.ts
+++ b/src/type/survey/surveyResponse.ts
@@ -58,3 +58,8 @@ export interface PutSurveyResponse {
     updatedAt: Date | null;
   }[];
 }
+
+export interface PostSurveyResponsesResponse {
+  responseId: number;
+  surveyId: number;
+}

--- a/src/utils/getTextResponseByQuestionText.ts
+++ b/src/utils/getTextResponseByQuestionText.ts
@@ -1,7 +1,7 @@
-import { SatisfactionDistributionItem } from '@/type/survey/surveyResponse';
+import { Question } from '@/type/survey/surveyResponse';
 
 export const getTextResponsesByQuestionText = (
-  satisfactionDistributions: SatisfactionDistributionItem[],
+  satisfactionDistributions: Question[],
   questionText: string,
 ): string[] | null => {
   const foundItem = satisfactionDistributions.find(


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 설문별 설문 응답페이지로 가기 위한 qrCode 생성
- api를 통해 받은 base64형식의 문자열 디코딩 후 이미지로 렌더링


## 스크린샷

![image](https://github.com/user-attachments/assets/4c44b63c-1e52-4adc-90ff-9c9df22e9e3c)


## 리뷰 요구사항

- 기본적인 qrCode의 배경색이 흰색으로 되어있어서 살짝 불편하긴한데 변경방법이 있나 찾아보겠습니다
- qr찍으면 라우팅되는 url은 일단은 네이버로 해두었는데, 사이트 배포할 때 한번에 수정하겠습니다
- 설문 api 수정 작업내뇽까지 들어가 있어서 코드가 좀 많은데, 제일 하단 6개 커밋으로 확인해주시면 감사하겠슴닷
