### PR TITLE
Feat[#THKV-86] : 월별 레시피 조회 api 연결

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,16 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'http',
+        hostname: 'www.nongsaro.go.kr',
+        port: '',
+        pathname: '/**/**/*',
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/api/openAPI/index.ts
+++ b/src/api/openAPI/index.ts
@@ -1,0 +1,15 @@
+import { get } from '@/lib/axios';
+import { MenuRecipeListResponse } from '@/type/openAPI/recipeResponse';
+import { Result } from '@/type/response';
+import { OPEN_API } from '@/constants/_apiPath';
+
+const { RECIPE } = OPEN_API;
+
+const getMonthRecipeList = async () => {
+  const response = await get<Result<MenuRecipeListResponse[]>>(RECIPE);
+  return response.data;
+};
+
+export const openAPI = {
+  getMonthRecipeList,
+};

--- a/src/components/feature/MyPage/index.tsx
+++ b/src/components/feature/MyPage/index.tsx
@@ -67,7 +67,7 @@ const MyPage = () => {
   });
   const { data: mealListTotalItems } = useGetMenuCount();
   const mealTotalItems = isSuccess
-    ? mealListTotalItems!.data.totalMenuCount
+    ? mealListTotalItems?.data.totalMenuCount
     : 0;
 
   const {

--- a/src/components/shared/Main/Body/index.tsx
+++ b/src/components/shared/Main/Body/index.tsx
@@ -3,7 +3,6 @@
 import dayjs from 'dayjs';
 import { MenuResponseDTO } from '@/type/menu/menuResponse';
 import { MenuRecipeListResponse } from '@/type/openAPI/recipeResponse';
-import { getCurrentYearMonthNow } from '@/utils/calendar';
 import { calculateUpdownPercent, countSurveysByMonth } from '@/utils/survey';
 import { TableRowData } from '@/components/common/Table';
 import { CardTitle, NutritionDate } from '@/components/common/Typography';
@@ -67,7 +66,6 @@ const MainPageBody = () => {
       ];
 
   const { navigate } = useNavigate();
-  const { month } = getCurrentYearMonthNow();
 
   const convertToTableRowData = (menus: MenuResponseDTO[]): TableRowData[] => {
     return menus.map((menu) => ({
@@ -129,7 +127,7 @@ const MainPageBody = () => {
         </div>
       </div>
       <div className='flex w-full flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
-        <CardTitle>{`${month}월의 제철 메뉴 / 식재료`}</CardTitle>
+        <CardTitle>{`${recipeData[0].month}월의 제철 레시피`}</CardTitle>
         <SeasonCard data={recipeData} />
       </div>
     </div>

--- a/src/components/shared/Main/Body/index.tsx
+++ b/src/components/shared/Main/Body/index.tsx
@@ -2,6 +2,7 @@
 
 import dayjs from 'dayjs';
 import { MenuResponseDTO } from '@/type/menu/menuResponse';
+import { MenuRecipeListResponse } from '@/type/openAPI/recipeResponse';
 import { getCurrentYearMonthNow } from '@/utils/calendar';
 import { calculateUpdownPercent, countSurveysByMonth } from '@/utils/survey';
 import { TableRowData } from '@/components/common/Table';
@@ -13,9 +14,9 @@ import MiniCard from '@/components/shared/Main/Cards/MiniCard';
 import SeasonCard from '@/components/shared/Main/Cards/SeasonCard';
 import { DETAIL_SURVEY_DATA } from '@/constants/_detailSurvey';
 import { ROUTES } from '@/constants/_navbar';
-import { SEASON_DATA } from '@/constants/_seasonData';
 import { useGetMealList } from '@/hooks/meal/useGetMealList';
 import { useGetMenuCount } from '@/hooks/menu/useGetMenuCount';
+import { useGetMenuRecipeList } from '@/hooks/openAPI/useGetMenuRecipeList';
 import { useGetSurveyList } from '@/hooks/survey/useGetSurveyList';
 import useNavigate from '@/hooks/useNavigate';
 
@@ -23,10 +24,16 @@ const SURVEY_LIST_SIZE = 5;
 // TODO: ** 설문 좋아요/싫어요 top3 메뉴 API 연결
 const { likedMenusTop3, satisfactionDistribution } = DETAIL_SURVEY_DATA;
 
-// TODO: ** 제철 메뉴 API 연결
 const MainPageBody = () => {
   const { data: surveyList, isSuccess } = useGetSurveyList({});
   const { data: mealCounts, isSuccess: isMealCountSuccess } = useGetMenuCount();
+  const { data: recipeList, isSuccess: isRecipeSuccess } =
+    useGetMenuRecipeList();
+  const { data: mealList } = useGetMealList({
+    page: 0,
+    sort: 'createdAt,desc',
+    size: SURVEY_LIST_SIZE,
+  });
 
   const surveyTotalItems = isSuccess ? surveyList!.data.totalItems : 0;
   const { thisMonth, lastMonth } = isSuccess
@@ -44,23 +51,36 @@ const MainPageBody = () => {
   );
   const upDownSurveyPercent = calculateUpdownPercent(thisMonth, lastMonth);
 
+  const recipeData = isRecipeSuccess
+    ? recipeList!.data
+    : [
+        {
+          recipeId: '',
+          month: 0,
+          recipeName: '',
+          mainIngredient: '',
+          subIngredient: '',
+          instructions: '',
+          forGroup: '',
+          imageUrl: '',
+        } as MenuRecipeListResponse,
+      ];
+
   const { navigate } = useNavigate();
   const { month } = getCurrentYearMonthNow();
 
-  const { data: mealList } = useGetMealList({
-    page: 0,
-    sort: 'createdAt,desc',
-    size: SURVEY_LIST_SIZE,
-  });
-
   const convertToTableRowData = (menus: MenuResponseDTO[]): TableRowData[] => {
     return menus.map((menu) => ({
-      식단ID: menu.monthMenuId.substring(0, 4),
+      식단ID: menu.monthMenuId,
       식단이름: menu.monthMenuName,
       대분류: menu.majorCategory,
       소분류: menu.minorCategory,
       생성일: dayjs(menu.createAt).format('YYYY-MM-DD'),
     }));
+  };
+
+  const handleRowClick = (id: string | number) => {
+    navigate(`${ROUTES.VIEW.PLAN}/${id}`);
   };
 
   return (
@@ -99,9 +119,7 @@ const MainPageBody = () => {
               data={convertToTableRowData(
                 mealList.data.menuResponseDTOList.slice(0, 5),
               )}
-              onRowClick={(id) => {
-                navigate(`${ROUTES.VIEW.PLAN}/${id}`);
-              }}
+              onRowClick={(id) => handleRowClick(id)}
             />
           ) : (
             <div className='mt-1 flex justify-center'>
@@ -112,7 +130,7 @@ const MainPageBody = () => {
       </div>
       <div className='flex w-full flex-col gap-3 rounded border border-gray-300 bg-white-100 p-5'>
         <CardTitle>{`${month}월의 제철 메뉴 / 식재료`}</CardTitle>
-        <SeasonCard data={SEASON_DATA} />
+        <SeasonCard data={recipeData} />
       </div>
     </div>
   );

--- a/src/components/shared/Main/Cards/SeasonCard/index.tsx
+++ b/src/components/shared/Main/Cards/SeasonCard/index.tsx
@@ -1,29 +1,26 @@
 import Image from 'next/image';
+import { MenuRecipeListResponse } from '@/type/openAPI/recipeResponse';
 
-interface Props {
-  data: {
-    name: string;
-    id: number;
-    img: string;
-  }[];
-}
+type SeasonCardProps = {
+  data: MenuRecipeListResponse[];
+};
 
-const SeasonCard = ({ data }: Props) => {
+const SeasonCard = ({ data }: SeasonCardProps) => {
   return (
     <div className='flex w-full gap-2'>
-      {data.map((season) => (
+      {data?.map((recipe) => (
         <div
           className='flex w-full flex-col items-center gap-3'
-          key={season.id}
+          key={recipe.recipeId}
         >
           <Image
-            src={season.img}
-            alt={season.name}
+            src={recipe.imageUrl}
+            alt={recipe.recipeName}
             width={180}
             height={180}
             className='rounded'
           />
-          <span className='font-semibold'>{season.name}</span>
+          <span className='font-semibold'>{recipe.recipeName}</span>
         </div>
       ))}
     </div>

--- a/src/constants/_apiPath.ts
+++ b/src/constants/_apiPath.ts
@@ -7,6 +7,7 @@ export const BASE_API = {
   MONTH_MENUS: '/month-menus',
   MENU_CATEGORIES: '/menu-categories',
   USERS: '/users',
+  OPEN_APIS: '/open-apis',
 };
 
 /**
@@ -58,4 +59,11 @@ export const USER_API = {
   USERS: BASE_API.USERS,
   CHECK_PW: `${BASE_API.USERS}/check-pw`,
   EDIT_PW: `${BASE_API.USERS}/edit-pw`,
+};
+
+/**
+ * @description user API endpoints
+ */
+export const OPEN_API = {
+  RECIPE: `${BASE_API.OPEN_APIS}/recipe`,
 };

--- a/src/hooks/openAPI/useGetMenuRecipeList.ts
+++ b/src/hooks/openAPI/useGetMenuRecipeList.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { openAPI } from '@/api/openAPI';
+
+export const useGetMenuRecipeList = () => {
+  return useQuery({
+    queryKey: ['menuRecipeList'],
+    queryFn: () => openAPI.getMonthRecipeList(),
+  });
+};

--- a/src/type/openAPI/recipeResponse.ts
+++ b/src/type/openAPI/recipeResponse.ts
@@ -1,0 +1,10 @@
+export interface MenuRecipeListResponse {
+  recipeId: string;
+  month: number;
+  recipeName: string;
+  mainIngredient: string;
+  subIngredient: string;
+  instructions: string;
+  forGroup: string;
+  imageUrl: string;
+}


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->
### Feat
- 홈 대시보드 -  월별 레시피 조회 api 연결
- nextconfig image remort patterns 설정

### Fix
- SeasonCard - 타입 수정
- 마이페이지 - 식단 전체 개수 조회 `!.` -> `?.` 으로 수정

### 설명 (선택)

- 마이페이지에서 에러 발생해서 83번 작업내용이지만 어쩔 수 없이 이 브랜치에서 수정했습니다!

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- 83번 브랜치 작업 내용이 필요해서, 83번에서 브랜치 분기해서 작업했습니다!
- `open api, recipe api 경로 정의` 커밋부터 확인하시면 됩니다.
![image](https://github.com/user-attachments/assets/fd26fab0-8576-4404-a029-31c5e6db63f3)

