### PR TITLE
Feat,Fix[#THKV-88] : 식단 검색 api 연결

### DIFF
--- a/src/api/meal/index.ts
+++ b/src/api/meal/index.ts
@@ -5,32 +5,43 @@ import {
 } from '@/type/menu/menuRequest';
 import { MonthMenusResponse } from '@/type/menu/menuResponse';
 import { Result } from '@/type/response';
-import { BASE_API } from '@/constants/_apiPath';
+import { MENUS_API } from '@/constants/_apiPath';
+
+const { MONTH_MENUS, SEARCH } = MENUS_API;
 
 const getMealList = async ({
   size = 8,
   page,
   sort = 'createdAt,desc',
 }: GetMealListReqeust) => {
-  const response = await get<Result<MonthMenusResponse>>(BASE_API.MONTH_MENUS, {
+  const response = await get<Result<MonthMenusResponse>>(MONTH_MENUS, {
     params: { page, sort, size },
   });
   return response.data;
 };
 
 const getSearchMealList = async ({
+  majorCategory,
+  minorCategory,
+  menuName,
+  year,
+  month,
   size = 8,
   page,
   sort = 'createdAt,desc',
-  majorCategory,
-  minorCategory,
 }: GetSearchMealListRequest) => {
-  const response = await get<Result<MonthMenusResponse>>(
-    `${BASE_API.MENU_CATEGORIES}${BASE_API.MONTH_MENUS}?major-category=${majorCategory}&minor-category=${minorCategory}`,
-    {
-      params: { page, sort, size },
+  const response = await get<Result<MonthMenusResponse>>(SEARCH, {
+    params: {
+      ...(majorCategory != null && { majorCategory }),
+      ...(minorCategory != null && { minorCategory }),
+      ...(menuName != null && { menuName }),
+      ...(year != null && { year }),
+      ...(month != null && { month }),
+      page,
+      sort,
+      size,
     },
-  );
+  });
   return response.data;
 };
 

--- a/src/components/common/Selectbox/index.tsx
+++ b/src/components/common/Selectbox/index.tsx
@@ -28,7 +28,7 @@ export type SelectboxProps = VariantProps<typeof selectboxVariants> & {
 
 export const Selectbox = ({
   options,
-  placeholder = '소분류를 선택해주세요.',
+  placeholder = '분류를 선택해주세요.',
   size = 'small',
   className,
   onChange,

--- a/src/components/feature/AutoPlanCreate/index.tsx
+++ b/src/components/feature/AutoPlanCreate/index.tsx
@@ -15,6 +15,7 @@ import {
   getCurrentYearMonthNow,
   transformResponseToCalendar,
   transformCalendarToPostSave,
+  isAllFoodsEmpty,
 } from '@/utils/calendar';
 import MealForm from '@/components/common/MealForm';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
@@ -68,6 +69,11 @@ const AutoPlanCreate = () => {
   };
 
   const onSubmit = (data: MealHeaderFormData) => {
+    if (isAllFoodsEmpty(calendarData)) {
+      showToast('빈 식단은 생성할 수 없습니다.', 'warning', 3000);
+      return;
+    }
+
     const formattedData = transformCalendarToPostSave(
       calendarData,
       data.monthMenuName,

--- a/src/components/feature/ViewChart/index.tsx
+++ b/src/components/feature/ViewChart/index.tsx
@@ -87,7 +87,7 @@ const ViewChart = () => {
             onMonthChange={setSelectedMonth}
             onYearChange={setSelectedYear}
             searchValue={searchValue}
-            handlechangeSearchValue={handleChangeSearchValue}
+            handleChangeSearchValue={handleChangeSearchValue}
             selectedFilter={selectedFilter}
             setSelectedFilter={setSelectedFilter}
             selectedTab={selectedTab}

--- a/src/components/shared/GetAllList/Controls/index.tsx
+++ b/src/components/shared/GetAllList/Controls/index.tsx
@@ -17,7 +17,7 @@ interface Props {
   organization?: string;
   setOrganization?: React.Dispatch<React.SetStateAction<string>>;
   searchValue: string;
-  handlechangeSearchValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleChangeSearchValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
   selectedFilter?: string;
   setSelectedFilter?: React.Dispatch<React.SetStateAction<string>>;
   selectedTab: string;
@@ -38,7 +38,7 @@ const GetAllListControls = ({
   organization,
   setOrganization,
   searchValue,
-  handlechangeSearchValue,
+  handleChangeSearchValue,
   selectedFilter,
   setSelectedFilter,
   selectedTab,
@@ -78,7 +78,7 @@ const GetAllListControls = ({
             bgcolor='meal'
             includeButton={true}
             value={searchValue}
-            onChange={handlechangeSearchValue}
+            onChange={handleChangeSearchValue}
             onSubmit={handleSearchSubmit}
           />
           {type === 'viewPlan' && setOrganization && setSelectedCategory && (
@@ -87,6 +87,7 @@ const GetAllListControls = ({
                 options={ORGANIZATION_LIST}
                 size='small'
                 onChange={handleOrganizationChange}
+                selectedValue={organization}
               />
               {ORGANIZATION_LIST.map(
                 (item) =>

--- a/src/constants/_apiPath.ts
+++ b/src/constants/_apiPath.ts
@@ -41,6 +41,7 @@ export const MENUS_API = {
   FOODS: `${BASE_API.MONTH_MENUS}/foods`,
   FOOD_NAME: 'foodName',
   COUNT: `${BASE_API.MONTH_MENUS}/count`,
+  SEARCH: `${BASE_API.MONTH_MENUS}/search`,
 };
 
 /**

--- a/src/hooks/meal/queryKey.ts
+++ b/src/hooks/meal/queryKey.ts
@@ -10,5 +10,12 @@ export const mealKeys = {
   sort: (request?: GetMealListReqeust) =>
     [...mealKeys.lists(), request] as const,
   search: (request?: GetSearchMealListRequest) =>
-    [...mealKeys.lists(), request] as const,
+    [
+      ...mealKeys.lists(),
+      request?.majorCategory,
+      request?.minorCategory,
+      request?.menuName,
+      request?.year,
+      request?.month,
+    ] as const,
 };

--- a/src/hooks/meal/useGetSearchMealList.ts
+++ b/src/hooks/meal/useGetSearchMealList.ts
@@ -3,10 +3,15 @@ import { meal } from '@/api/meal';
 import { GetSearchMealListRequest } from '@/type/menu/menuRequest';
 import { mealKeys } from '@/hooks/meal/queryKey';
 
-export const useGetSearchMealList = (request: GetSearchMealListRequest) => {
+export const useGetSearchMealList = (
+  request: GetSearchMealListRequest,
+  options?: {
+    enabled?: boolean;
+  },
+) => {
   return useQuery({
     queryKey: mealKeys.search(request),
     queryFn: () => meal.getSearchMealList(request),
-    enabled: !!request.majorCategory && !!request.minorCategory,
+    ...options,
   });
 };

--- a/src/type/menu/menuRequest.ts
+++ b/src/type/menu/menuRequest.ts
@@ -47,12 +47,16 @@ export interface GetFoodsRequest {
 export interface GetMealListReqeust {
   page: number;
   size: number;
+  // TODO: 타입 분리해서 selectedTab 타입으로 적용
   sort: 'createdAt,desc' | 'createdAt,asc';
 }
 
 export interface GetSearchMealListRequest extends GetMealListReqeust {
-  majorCategory: string;
-  minorCategory: string;
+  majorCategory?: string;
+  minorCategory?: string;
+  menuName?: string;
+  year?: string;
+  month?: string;
 }
 
 export interface GetMonthMenuDetailRequest {

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -200,3 +200,13 @@ export const getYearAndMonth = (createdAt: string) => {
 
   return { year, month };
 };
+
+/**
+ * @description 식단 데이터가 비어있는 지 확인
+ * @param calendarData
+ */
+export const isAllFoodsEmpty = (calendarData: CalendarInfo): boolean => {
+  return Object.values(calendarData).every(
+    (dateData) => dateData.foods.length === 0,
+  );
+};


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

### Fix
- 식단 전체 조회 api 대신 식단 검색 api로 교체
- 자동 식단 생성 페이지 : 비어있는 식단 생성 못하게 막음
- Controls : 대분류 state값 selectbox value로 전달

### 설명 (선택)

상세한 설명

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

- 식단 목록 조회 페이지에서 api 코드 대거 교체했습니다. 기존에 승현님이 식단 전체조회 api 연결해두셨었는데, 생각해보니 그걸 쓸 수가 없더라고요. 그 api에서는 연월 필터가 안 되는데, 식단 목록 조회 페이지에서 식단들은 무조건 현재 연/월로 필터를 한 번 거쳐서 보여지잖아여. 식단 전체조회 api랑 식단 검색 api 두 개를 같이 쓰려고 계속 생각해서 버그도 많고 머리 아팠는데, 식단 검색 api로 교체했더니 문제가 쉽게 해결됐습니다.
- 그리고 전에 계속 검색 api에서 오래된순 정렬이 안 된다고 했었는데, 그거는 백엔드에서 sort 파람 값을 `createAt`으로 설정해두고 명세서에는 `createdAt`으로 적어두셔서 그랬던 거였습니다. 저는 백엔드에 `createdAt`으로 보냈는데 백엔드에서는 `createAt`으로 설정해놔서 필터가 안 됐던 거였어요. 그래서 그거 오늘 고쳐주셔서 해결됐습니다.
- 이 브랜치가 3일동안 잡고 있던 거라 변경한 파일들이 조금 많습니다. 양해 부탁드립니다!
