### PR TITLE
Fix[#THKV-102]: 식단 / 설문 조회 기본 년, 월 빼고 전체 먼저 조회

### DIFF
--- a/src/components/common/DatePicker/index.tsx
+++ b/src/components/common/DatePicker/index.tsx
@@ -37,7 +37,8 @@ const DatePicker = ({
         <Selectbox
           options={years}
           onChange={onYearChange}
-          placeholder={selectedYear}
+          placeholder='년도'
+          selectedValue={selectedYear.toString()}
         />
       </div>
       <div className='flex flex-col gap-1'>
@@ -45,7 +46,8 @@ const DatePicker = ({
         <Selectbox
           options={months}
           onChange={onMonthChange}
-          placeholder={selectedMonth}
+          placeholder='월'
+          selectedValue={selectedMonth.toString()}
         />
       </div>
     </div>

--- a/src/components/feature/ViewChart/index.tsx
+++ b/src/components/feature/ViewChart/index.tsx
@@ -4,7 +4,6 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import { surveyType } from '@/type/survey/surveyResponse';
-import { getCurrentYearMonthNow } from '@/utils/calendar';
 import Pagination from '@/components/common/Pagination';
 import { HeadPrimary } from '@/components/common/Typography';
 import GetAllListControls from '@/components/shared/GetAllList/Controls';
@@ -20,15 +19,11 @@ const ViewChart = () => {
   const sort = searchParam.get('sort') as string;
   const currentTab = sort ?? ('최신순' as string);
 
-  const { month, year } = getCurrentYearMonthNow();
-
   const [searchValue, setSearchValue] = useState('');
   const [actualSearchValue, setActualSearchValue] = useState('');
 
-  const [selectedYear, setSelectedYear] = useState<string>(year.toString());
-  const [selectedMonth, setSelectedMonth] = useState<string>(
-    month.toString().padStart(2, '0'),
-  );
+  const [selectedYear, setSelectedYear] = useState<string>('');
+  const [selectedMonth, setSelectedMonth] = useState<string>('');
   const [selectedFilter, setSelectedFilter] = useState<string>(
     SURVEY_FILTER_OPTIONS[0],
   );
@@ -58,8 +53,14 @@ const ViewChart = () => {
         : selectedFilter === '진행중'
           ? 'IN_PROGRESS'
           : 'CLOSED',
-    startDate: `${selectedYear}-${selectedMonth.toString().padStart(2, '0')}-01T00:00:00`,
-    endDate: `${selectedYear}-${selectedMonth.toString().padStart(2, '0')}-31T23:59:59`,
+    startDate:
+      selectedMonth && selectedYear
+        ? `${selectedYear}-${selectedMonth.toString().padStart(2, '0')}-01T00:00:00`
+        : undefined,
+    endDate:
+      selectedMonth && selectedYear
+        ? `${selectedYear}-${selectedMonth.toString().padStart(2, '0')}-31T23:59:59`
+        : undefined,
   });
 
   useEffect(() => {
@@ -97,7 +98,7 @@ const ViewChart = () => {
             handleSearchSubmit={handleSearchSubmit}
           />
           {surveyList?.data.totalItems === 0 ? (
-            <HeadPrimary>메뉴가 존재하지 않습니다</HeadPrimary>
+            <HeadPrimary>설문이 존재하지 않습니다</HeadPrimary>
           ) : (
             <>
               <GetAllListTable

--- a/src/components/feature/ViewPlan/index.tsx
+++ b/src/components/feature/ViewPlan/index.tsx
@@ -5,7 +5,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { MenuResponseDTO } from '@/type/menu/menuResponse';
 import { Result } from '@/type/response';
-import { getCurrentYearMonthNow } from '@/utils/calendar';
+// import { getCurrentYearMonthNow } from '@/utils/calendar';
 import { findOriginalId } from '@/utils/findOriginalId';
 import Pagination from '@/components/common/Pagination';
 import { Option } from '@/components/common/Selectbox';
@@ -37,9 +37,9 @@ const ViewPlan = () => {
     usePrefetchMinorCategories();
   const [minorCategories, setMinorCategories] = useState<Option[]>([]);
 
-  const { month, year } = getCurrentYearMonthNow();
-  const [selectedYear, setSelectedYear] = useState<string>(year.toString());
-  const [selectedMonth, setSelectedMonth] = useState<string>(month.toString());
+  // const { month, year } = getCurrentYearMonthNow();
+  const [selectedYear, setSelectedYear] = useState<string>('');
+  const [selectedMonth, setSelectedMonth] = useState<string>('');
   const [searchInputValue, setSearchInputValue] = useState('');
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedOrganization, setSelectedOrganization] = useState<string>('');
@@ -48,23 +48,32 @@ const ViewPlan = () => {
   const [page, setPage] = useState(DEFAULT_PAGE);
   const [isSearchClicked, setIsSearchClicked] = useState(false);
 
+  // const searchTriggerCondition =
+  //   // 1. 대분류, 소분류 값있을 때
+  //   !!(selectedOrganization && selectedCategory) ||
+  //   // 2. 기본 연월과 다른 연월 선택했을 때
+  //   !!(
+  //     selectedYear !== year.toString() || selectedMonth !== month.toString()
+  //   ) ||
+  //   // 3. 오래된 순이면서 다른 파람들 중에 유효한 값이 하나라도 있어야 함
+  //   !!(
+  //     selectedTab !== TAB_OPTIONS[0] ||
+  //     // 대분류 + 소분류 선택되거나
+  //     (selectedOrganization && selectedCategory) ||
+  //     // 기본 연월과 다른 연월 선택했을 때
+  //     selectedYear !== year.toString() ||
+  //     selectedMonth !== month.toString()
+  //   ) ||
+  //   // 4. 검색어 있고 검색버튼 클릭 됐을 때
+  //   !!isSearchClicked;
   const searchTriggerCondition =
-    // 1. 대분류, 소분류 값있을 때
+    // 1. 대분류, 소분류 값이 있을 때
     !!(selectedOrganization && selectedCategory) ||
-    // 2. 기본 연월과 다른 연월 선택했을 때
-    !!(
-      selectedYear !== year.toString() || selectedMonth !== month.toString()
-    ) ||
-    // 3. 오래된 순이면서 다른 파람들 중에 유효한 값이 하나라도 있어야 함
-    !!(
-      selectedTab !== TAB_OPTIONS[0] &&
-      // 대분류 + 소분류 선택되거나
-      ((selectedOrganization && selectedCategory) ||
-        // 기본 연월과 다른 연월 선택했을 때
-        selectedYear !== year.toString() ||
-        selectedMonth !== month.toString())
-    ) ||
-    // 4. 검색어 있고 검색버튼 클릭 됐을 때
+    // 2. 특정 연도와 월이 선택된 경우 (초기에는 전체 리스트를 가져오기 위해 빈 문자열이면 false)
+    !!(selectedYear || selectedMonth) ||
+    // 3. 오래된 순이면서 다른 파라미터 중에 유효한 값이 하나라도 있는 경우
+    selectedTab !== TAB_OPTIONS[0] ||
+    // 4. 검색어가 있고, 검색 버튼이 클릭되었을 때
     !!isSearchClicked;
 
   const { data: searchMealList, refetch: searchMealRefetch } =


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 식단 / 설문 조회 페이지 전체조회 먼저
- 설문 데이터가 없을 때의 오타 수정


## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->

## 리뷰 요구사항

- 우림님이 작성하신 searchTrigger 함수의 조건때문에 현재 년,월일때는 refetch안하는 버그가 있어서
원래 코드는 주석처리하고, 아래에 새로 작성했습니다! 참고 부탁드려영
