### PR TITLE
Feat[THKV-115]: Table, TableBody, TableHeader 컴포넌트 리디자인 적용

### DIFF
--- a/src/components/common/ControlTab/index.tsx
+++ b/src/components/common/ControlTab/index.tsx
@@ -4,14 +4,15 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Dispatch, SetStateAction } from 'react';
 import { cn } from '@/utils/core';
+import { ControlTabTypo } from '../Typography';
 
 type Props<T> = {
   type?: string;
   controlTabItems: readonly T[];
-  selectedFilter: string;
-  setSelectedFilter: Dispatch<SetStateAction<string>>;
-  selectedTab: T;
-  setSelectedTab: Dispatch<SetStateAction<T>>;
+  selectedFilter?: string;
+  setSelectedFilter?: Dispatch<SetStateAction<string>>;
+  selectedTab?: T;
+  setSelectedTab?: Dispatch<SetStateAction<T>>;
 };
 
 const ControlTab = <T extends string>({
@@ -27,7 +28,12 @@ const ControlTab = <T extends string>({
   const currentTab = tabParam ?? ('전체' as string);
 
   return (
-    <div className='flex gap-2'>
+    <div
+      className={cn(
+        'flex justify-end gap-3',
+        type !== 'sort' ? 'border-r border-grey-100 pr-6' : '',
+      )}
+    >
       {controlTabItems.map((tab) => (
         <Link
           href={
@@ -36,21 +42,22 @@ const ControlTab = <T extends string>({
               : `?tab=${tab}&sort=${selectedTab}`
           }
           key={tab}
-          className={cn(
-            'text-xs text-gray-400',
-            (tab === currentTab || tab === selectedTab) &&
-              'font-semibold text-green-600',
-          )}
           replace
           onClick={() => {
             if (type === 'sort') {
-              setSelectedTab(tab);
+              setSelectedTab!(tab);
             } else {
-              setSelectedFilter(tab);
+              setSelectedFilter!(tab);
             }
           }}
         >
-          {tab}
+          <ControlTabTypo
+            className={
+              tab === currentTab || tab === selectedTab ? 'text-green-500' : ''
+            }
+          >
+            {tab}
+          </ControlTabTypo>
         </Link>
       ))}
     </div>

--- a/src/components/common/ControlTab/index.tsx
+++ b/src/components/common/ControlTab/index.tsx
@@ -4,10 +4,10 @@ import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { Dispatch, SetStateAction } from 'react';
 import { cn } from '@/utils/core';
-import { ControlTabTypo } from '../Typography';
+import { ControlTabTypo } from '@/components/common/Typography';
 
 type Props<T> = {
-  type?: string;
+  isSortControl?: boolean;
   controlTabItems: readonly T[];
   selectedFilter?: string;
   setSelectedFilter?: Dispatch<SetStateAction<string>>;
@@ -16,7 +16,7 @@ type Props<T> = {
 };
 
 const ControlTab = <T extends string>({
-  type,
+  isSortControl,
   controlTabItems,
   selectedFilter,
   setSelectedFilter,
@@ -31,20 +31,20 @@ const ControlTab = <T extends string>({
     <div
       className={cn(
         'flex justify-end gap-3',
-        type !== 'sort' ? 'border-r border-grey-100 pr-6' : '',
+        !isSortControl ? 'border-r border-grey-100 pr-6' : '',
       )}
     >
       {controlTabItems.map((tab) => (
         <Link
           href={
-            type === 'sort'
+            isSortControl
               ? `${selectedFilter === undefined ? `?sort=${tab}` : `?tab=${selectedFilter}&sort=${tab}`}`
               : `?tab=${tab}&sort=${selectedTab}`
           }
           key={tab}
           replace
           onClick={() => {
-            if (type === 'sort') {
+            if (isSortControl) {
               setSelectedTab!(tab);
             } else {
               setSelectedFilter!(tab);

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -12,7 +12,6 @@ interface Props {
   totalPosts: number;
 }
 
-const PAGE_LIMIT = 10;
 const ZERO = 0;
 const ONE = 1;
 
@@ -20,7 +19,7 @@ const Pagination = ({ limit, page, setPage, totalPosts }: Props) => {
   const [blockNum, setBlockNum] = useState(0);
 
   const totalPages = Math.ceil(totalPosts / limit);
-  const blockArea = blockNum * PAGE_LIMIT;
+  const blockArea = blockNum * limit;
 
   const createArr = Array(totalPages)
     .fill(ZERO)
@@ -41,7 +40,7 @@ const Pagination = ({ limit, page, setPage, totalPosts }: Props) => {
       </Button>
     ));
 
-  const sliceArr = createArr.slice(blockArea, PAGE_LIMIT + blockArea);
+  const sliceArr = createArr.slice(blockArea, limit + blockArea);
 
   const firstPage = () => {
     setPage(ONE);
@@ -50,12 +49,12 @@ const Pagination = ({ limit, page, setPage, totalPosts }: Props) => {
 
   const lastPage = () => {
     setPage(totalPages);
-    setBlockNum(Math.ceil(totalPages / PAGE_LIMIT) - ONE);
+    setBlockNum(Math.ceil(totalPages / limit) - ONE);
   };
 
   const prevBtnHandler = () => {
     if (page > ONE) {
-      if (page - ONE <= PAGE_LIMIT * blockNum) {
+      if (page - ONE <= limit * blockNum) {
         setBlockNum((num) => Math.max(num - ONE, 0));
       }
       setPage((num) => num - ONE);
@@ -64,7 +63,7 @@ const Pagination = ({ limit, page, setPage, totalPosts }: Props) => {
 
   const nextBtnHandler = () => {
     if (page < totalPages) {
-      if (page + ONE > PAGE_LIMIT * (blockNum + ONE)) {
+      if (page + ONE > limit * (blockNum + ONE)) {
         setBlockNum((num) => num + ONE);
       }
       setPage((num) => num + ONE);
@@ -112,14 +111,14 @@ const Pagination = ({ limit, page, setPage, totalPosts }: Props) => {
       </Button>
       <Button
         onClick={lastPage}
-        disabled={blockArea >= totalPages - PAGE_LIMIT}
+        disabled={blockArea >= totalPages - limit}
         variant='pagination'
       >
         <Icon
           name='arrowNextBlock'
           width={24}
           height={24}
-          color={blockArea >= totalPages - PAGE_LIMIT ? 'grey' : 'black'}
+          color={blockArea >= totalPages - limit ? 'grey' : 'black'}
         />
       </Button>
     </div>

--- a/src/components/common/Pagination/index.tsx
+++ b/src/components/common/Pagination/index.tsx
@@ -12,7 +12,7 @@ interface Props {
   totalPosts: number;
 }
 
-const PAGE_LIMIT = 5;
+const PAGE_LIMIT = 10;
 const ZERO = 0;
 const ONE = 1;
 
@@ -32,9 +32,9 @@ const Pagination = ({ limit, page, setPage, totalPosts }: Props) => {
         variant={'pagination'}
         className={cn(
           '',
-          page === i + ONE
-            ? 'bg-green-500 text-white-100 hover:bg-green-500'
-            : '',
+          page === i + ONE && 'bg-green-500 text-white-100 hover:bg-green-500',
+          totalPages === ONE &&
+            'cursor-default border-none bg-transparent text-green-500 hover:bg-transparent active:bg-transparent',
         )}
       >
         {i + ONE}

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -15,6 +15,7 @@ type TableProps = {
   headerClassName?: string;
   bodyClassName?: string;
   onRowClick?: (id: number | string) => void;
+  headerType: 'viewPlan' | 'viewChart';
 };
 
 const Table = ({
@@ -23,6 +24,7 @@ const Table = ({
   headerClassName,
   bodyClassName,
   onRowClick,
+  headerType,
 }: TableProps) => {
   const tableHeaders = Array.from(
     new Set(data.flatMap((item) => Object.keys(item))),
@@ -30,14 +32,19 @@ const Table = ({
 
   return (
     <div className='w-full'>
-      <table className='w-full border-separate border-spacing-0 overflow-hidden rounded-lg text-center'>
-        <TableHeader headerData={tableHeaders} className={headerClassName} />
+      <table className='w-full table-fixed'>
+        <TableHeader
+          headerData={tableHeaders}
+          className={headerClassName}
+          headerType={headerType}
+        />
         <TableBody
           headerData={tableHeaders}
           bodyData={data}
           type={type}
           className={bodyClassName}
           onRowClick={onRowClick}
+          headerType={headerType}
         />
       </table>
     </div>

--- a/src/components/common/Table/index.tsx
+++ b/src/components/common/Table/index.tsx
@@ -15,7 +15,7 @@ type TableProps = {
   headerClassName?: string;
   bodyClassName?: string;
   onRowClick?: (id: number | string) => void;
-  headerType: 'viewPlan' | 'viewChart';
+  headerType?: 'viewPlan' | 'viewChart';
 };
 
 const Table = ({
@@ -36,7 +36,7 @@ const Table = ({
         <TableHeader
           headerData={tableHeaders}
           className={headerClassName}
-          headerType={headerType}
+          headerType={headerType!}
         />
         <TableBody
           headerData={tableHeaders}
@@ -44,7 +44,7 @@ const Table = ({
           type={type}
           className={bodyClassName}
           onRowClick={onRowClick}
-          headerType={headerType}
+          headerType={headerType!}
         />
       </table>
     </div>

--- a/src/components/common/TableBody/index.tsx
+++ b/src/components/common/TableBody/index.tsx
@@ -8,7 +8,7 @@ type TableBodyProps = {
   type: TableType;
   className?: string;
   onRowClick?: (id: number | string) => void;
-  headerType: 'viewPlan' | 'viewChart';
+  headerType?: 'viewPlan' | 'viewChart';
 };
 
 const TableBody = ({

--- a/src/components/common/TableBody/index.tsx
+++ b/src/components/common/TableBody/index.tsx
@@ -40,7 +40,7 @@ const TableBody = ({
       {bodyData.map((item, rowIndex) => (
         <tr
           key={rowIndex}
-          className={cn('mx-3 h-16 cursor-pointer odd:bg-grey-50')}
+          className={cn('h-16 cursor-pointer odd:bg-grey-50 hover:bg-grey-100')}
           onClick={
             onRowClick && type === 'list' && typeof item.설문ID === 'number'
               ? () => onRowClick(item.설문ID as number)

--- a/src/components/common/TableBody/index.tsx
+++ b/src/components/common/TableBody/index.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/utils/core';
+import { TableBodyTypo } from '../Typography';
 import { TableRowData, TableType } from '@/components/common/Table';
 
 type TableBodyProps = {
@@ -7,6 +8,7 @@ type TableBodyProps = {
   type: TableType;
   className?: string;
   onRowClick?: (id: number | string) => void;
+  headerType: 'viewPlan' | 'viewChart';
 };
 
 const TableBody = ({
@@ -15,13 +17,30 @@ const TableBody = ({
   type,
   className,
   onRowClick,
+  headerType,
 }: TableBodyProps) => {
+  const planHeaderStyles: Record<string, string> = {
+    '식단 ID': 'w-[108px]',
+    '식단 이름': 'w-[924px]',
+    대분류: 'w-[128px]',
+    소분류: 'w-[264px]',
+    생성일: 'w-[124px]',
+  };
+
+  const surveyHeaderStyles: Record<string, string> = {
+    '설문 ID': 'w-[108px]',
+    '설문 이름': 'w-[948px]',
+    생성일: 'w-[184px]',
+    마감일: 'w-[184px]',
+    상태: 'w-[124px]',
+  };
+
   return (
-    <tbody className='bg-white-100'>
+    <tbody className='border-b border-grey-100 bg-white-100'>
       {bodyData.map((item, rowIndex) => (
         <tr
           key={rowIndex}
-          className='border-separate border-spacing-0 cursor-pointer'
+          className={cn('mx-3 h-16 cursor-pointer odd:bg-grey-50')}
           onClick={
             onRowClick && type === 'list' && typeof item.설문ID === 'number'
               ? () => onRowClick(item.설문ID as number)
@@ -30,28 +49,19 @@ const TableBody = ({
                 : undefined
           }
         >
-          {headerData.map((header, colIndex) => {
-            const isFirst = colIndex === 0;
-            const isLast = colIndex === headerData.length - 1;
-            const isLastRow = rowIndex === bodyData.length - 1;
-
-            const additionalClasses = cn({
-              'border-l': isFirst,
-              'border-r': isLast,
-              'rounded-bl-lg border-l border-b': isFirst && isLastRow,
-              'rounded-br-lg border-r border-b': isLast && isLastRow,
-            });
-
+          {headerData.map((header, idx) => {
+            const cellClass = cn(
+              'px-3',
+              idx === 0 ? 'pl-4' : idx === headerData.length - 1 ? 'pr-4' : '',
+              className,
+              (headerType === 'viewPlan' && planHeaderStyles[header]) || '',
+              (headerType === 'viewChart' && surveyHeaderStyles[header]) || '',
+            );
             return (
-              <td
-                key={header}
-                className={cn(
-                  'border-b border-gray-400 p-3',
-                  additionalClasses,
-                  className,
-                )}
-              >
-                {item[header] !== undefined ? item[header] : '-'}
+              <td key={header} className={cellClass}>
+                <TableBodyTypo>
+                  {item[header] !== undefined ? item[header] : '-'}
+                </TableBodyTypo>
               </td>
             );
           })}

--- a/src/components/common/TableBody/index.tsx
+++ b/src/components/common/TableBody/index.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/utils/core';
-import { TableBodyTypo } from '../Typography';
 import { TableRowData, TableType } from '@/components/common/Table';
+import { TableBodyTypo } from '@/components/common/Typography';
 
 type TableBodyProps = {
   headerData: string[];

--- a/src/components/common/TableHeader/index.tsx
+++ b/src/components/common/TableHeader/index.tsx
@@ -4,7 +4,7 @@ import { TableHeaderTypo } from '../Typography';
 type TableHeaderProps = {
   headerData: string[];
   className?: string;
-  headerType: 'viewPlan' | 'viewChart';
+  headerType?: 'viewPlan' | 'viewChart';
 };
 
 const TableHeader = ({

--- a/src/components/common/TableHeader/index.tsx
+++ b/src/components/common/TableHeader/index.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/utils/core';
-import { TableHeaderTypo } from '../Typography';
+import { TableHeaderTypo } from '@/components/common/Typography';
 
 type TableHeaderProps = {
   headerData: string[];

--- a/src/components/common/TableHeader/index.tsx
+++ b/src/components/common/TableHeader/index.tsx
@@ -1,36 +1,50 @@
 import { cn } from '@/utils/core';
+import { TableHeaderTypo } from '../Typography';
 
 type TableHeaderProps = {
   headerData: string[];
   className?: string;
+  headerType: 'viewPlan' | 'viewChart';
 };
 
-const TableHeader = ({ headerData, className }: TableHeaderProps) => {
+const TableHeader = ({
+  headerData,
+  className,
+  headerType,
+}: TableHeaderProps) => {
+  const planHeaderStyles: Record<string, string> = {
+    '식단 ID': 'w-[108px]',
+    '식단 이름': 'w-[924px]',
+    대분류: 'w-[128px]',
+    소분류: 'w-[264px]',
+    생성일: 'w-[124px]',
+  };
+
+  const surveyHeaderStyles: Record<string, string> = {
+    '설문 ID': 'w-[108px]',
+    '설문 이름': 'w-[948px]',
+    생성일: 'w-[184px]',
+    마감일: 'w-[184px]',
+    상태: 'w-[124px]',
+  };
+
   return (
-    <thead className='bg-green-100'>
-      <tr className='border-separate border-spacing-0'>
-        {headerData.map((header, index) => {
-          const isFirst = index === 0;
-          const isLast = index === headerData.length - 1;
-
-          const additionalClasses = cn({
-            'rounded-tl-lg border-l': isFirst,
-            'rounded-tr-lg border-r': isLast,
-          });
-
-          return (
-            <th
-              key={header}
-              className={cn(
-                'border-b border-t border-green-400 p-3 font-semibold',
-                additionalClasses,
-                className,
-              )}
-            >
-              {header}
-            </th>
-          );
-        })}
+    <thead className='h-12'>
+      <tr className='border-y border-grey-100'>
+        {headerData.map((header, idx) => (
+          <th
+            key={header}
+            className={cn(
+              'box-border px-3 text-start',
+              idx === 0 ? 'pl-4' : idx === headerData.length - 1 ? 'pr-4' : '',
+              className,
+              (headerType === 'viewPlan' && planHeaderStyles[header]) || '',
+              (headerType === 'viewChart' && surveyHeaderStyles[header]) || '',
+            )}
+          >
+            <TableHeaderTypo>{header}</TableHeaderTypo>
+          </th>
+        ))}
       </tr>
     </thead>
   );

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -2,6 +2,7 @@
 
 import { ComponentPropsWithoutRef, ElementType } from 'react';
 import { VariantProps } from 'class-variance-authority';
+import { cn } from '@/utils/core';
 import { typographyVariants } from './Typography.variant';
 
 export type TypographyProps = VariantProps<typeof typographyVariants> &
@@ -11,16 +12,21 @@ const customTypography = (
   element: ElementType,
   variants: VariantProps<typeof typographyVariants>,
 ) => {
-  const Typography = ({ children, ...props }: TypographyProps) => {
+  const Typography = ({ children, className, ...props }: TypographyProps) => {
     const Tag = element;
     return (
-      <Tag className={typographyVariants(variants)} {...props}>
+      <Tag className={cn(typographyVariants(variants), className)} {...props}>
         {children}
       </Tag>
     );
   };
   return Typography;
 };
+
+export const ControlTabTypo = customTypography('span', {
+  type: 'Body3',
+  color: 'gray',
+});
 
 // 리디자인 변경 전 Typography
 export const HeadPrimary = customTypography('h1', {

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -28,6 +28,16 @@ export const ControlTabTypo = customTypography('span', {
   color: 'gray',
 });
 
+export const TableHeaderTypo = customTypography('span', {
+  type: 'label1',
+  color: 'dark',
+});
+
+export const TableBodyTypo = customTypography('span', {
+  type: 'Body2',
+  color: 'dark',
+});
+
 // 리디자인 변경 전 Typography
 export const HeadPrimary = customTypography('h1', {
   type: 'heading1',

--- a/src/components/feature/ViewChart/index.tsx
+++ b/src/components/feature/ViewChart/index.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import dayjs from 'dayjs';
 import { surveyType } from '@/type/survey/surveyResponse';
+import ControlTab from '@/components/common/ControlTab';
 import Pagination from '@/components/common/Pagination';
 import { HeadPrimary } from '@/components/common/Typography';
 import GetAllListControls from '@/components/shared/GetAllList/Controls';
@@ -90,17 +91,30 @@ const ViewChart = () => {
             onYearChange={setSelectedYear}
             searchValue={searchValue}
             handleChangeSearchValue={handleChangeSearchValue}
-            selectedFilter={selectedFilter}
-            setSelectedFilter={setSelectedFilter}
-            selectedTab={selectedTab}
-            setSelectedTab={setSelectedTab}
             inputPlaceholder='설문 이름을 입력해주세요.'
             handleSearchSubmit={handleSearchSubmit}
           />
           {surveyList?.data.totalItems === 0 ? (
             <HeadPrimary>설문이 존재하지 않습니다</HeadPrimary>
           ) : (
-            <>
+            <div className='flex flex-col gap-6 rounded-2xl bg-white-100 p-6'>
+              <div className='flex items-center justify-end gap-6'>
+                <ControlTab
+                  controlTabItems={SURVEY_FILTER_OPTIONS}
+                  selectedFilter={selectedFilter!}
+                  setSelectedFilter={setSelectedFilter!}
+                  selectedTab={selectedTab}
+                  setSelectedTab={setSelectedTab}
+                />
+                <ControlTab
+                  type='sort'
+                  controlTabItems={TAB_OPTIONS}
+                  selectedFilter={selectedFilter!}
+                  setSelectedFilter={setSelectedFilter!}
+                  selectedTab={selectedTab}
+                  setSelectedTab={setSelectedTab}
+                />
+              </div>
               <GetAllListTable
                 data={convertToTableRowData(surveyList.data.surveys)}
                 onRowClick={(id) => router.push(`${ROUTES.VIEW.CHART}/${id}`)}
@@ -111,7 +125,7 @@ const ViewChart = () => {
                 setPage={setPage}
                 totalPosts={surveyList.data.totalItems}
               />
-            </>
+            </div>
           )}
         </>
       )}

--- a/src/components/feature/ViewChart/index.tsx
+++ b/src/components/feature/ViewChart/index.tsx
@@ -12,6 +12,7 @@ import GetAllListHeader from '@/components/shared/GetAllList/Header';
 import GetAllListTable from '@/components/shared/GetAllList/ListTable';
 import { SURVEY_FILTER_OPTIONS, TAB_OPTIONS } from '@/constants/_controlTab';
 import { ROUTES } from '@/constants/_navbar';
+import { PAGE_LIMIT } from '@/constants/_pagination';
 import { useGetSurveyList } from '@/hooks/survey/useGetSurveyList';
 
 const ViewChart = () => {
@@ -107,7 +108,7 @@ const ViewChart = () => {
                   setSelectedTab={setSelectedTab}
                 />
                 <ControlTab
-                  type='sort'
+                  isSortControl
                   controlTabItems={TAB_OPTIONS}
                   selectedFilter={selectedFilter!}
                   setSelectedFilter={setSelectedFilter!}
@@ -121,7 +122,7 @@ const ViewChart = () => {
                 headerType='viewChart'
               />
               <Pagination
-                limit={8}
+                limit={PAGE_LIMIT}
                 page={page}
                 setPage={setPage}
                 totalPosts={surveyList.data.totalItems}

--- a/src/components/feature/ViewChart/index.tsx
+++ b/src/components/feature/ViewChart/index.tsx
@@ -70,8 +70,8 @@ const ViewChart = () => {
 
   const convertToTableRowData = (surveys: surveyType[]) => {
     return surveys.map((survey) => ({
-      설문ID: survey.surveyId,
-      설문이름: survey.surveyName,
+      '설문 ID': survey.surveyId,
+      '설문 이름': survey.surveyName,
       생성일: dayjs(survey.createdAt).format('YYYY-MM-DD'),
       마감일: dayjs(survey.deadlineAt).format('YYYY-MM-DD'),
       상태: survey.state === 'IN_PROGRESS' ? '진행중' : '마감',
@@ -118,6 +118,7 @@ const ViewChart = () => {
               <GetAllListTable
                 data={convertToTableRowData(surveyList.data.surveys)}
                 onRowClick={(id) => router.push(`${ROUTES.VIEW.CHART}/${id}`)}
+                headerType='viewChart'
               />
               <Pagination
                 limit={8}

--- a/src/components/feature/ViewPlan/index.tsx
+++ b/src/components/feature/ViewPlan/index.tsx
@@ -5,7 +5,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import dayjs from 'dayjs';
 import { MenuResponseDTO } from '@/type/menu/menuResponse';
 import { Result } from '@/type/response';
-// import { getCurrentYearMonthNow } from '@/utils/calendar';
 import { findOriginalId } from '@/utils/findOriginalId';
 import ControlTab from '@/components/common/ControlTab';
 import Pagination from '@/components/common/Pagination';
@@ -18,15 +17,14 @@ import GetAllListTable from '@/components/shared/GetAllList/ListTable';
 import { CATEGORY_MAPPINGS } from '@/constants/_category';
 import { TAB_OPTIONS } from '@/constants/_controlTab';
 import { ROUTES } from '@/constants/_navbar';
+import { DEFAULT_PAGE, PAGE_LIMIT } from '@/constants/_pagination';
 import { useGetSearchMealList } from '@/hooks/meal/useGetSearchMealList';
 import { usePrefetchMinorCategories } from '@/hooks/menuCategory/usePrefetchMinorCategories';
 import useNavigate from '@/hooks/useNavigate';
 import { useToastStore } from '@/stores/useToastStore';
 
-const PAGE_LIMIT = 8;
 const SORT_DESC = 'createdAt,desc';
 const SORT_ASC = 'createdAt,asc';
-const DEFAULT_PAGE = 1;
 
 const ViewPlan = () => {
   const { navigate } = useNavigate();
@@ -37,7 +35,6 @@ const ViewPlan = () => {
     usePrefetchMinorCategories();
   const [minorCategories, setMinorCategories] = useState<Option[]>([]);
 
-  // const { month, year } = getCurrentYearMonthNow();
   const [selectedYear, setSelectedYear] = useState<string>('');
   const [selectedMonth, setSelectedMonth] = useState<string>('');
   const [searchInputValue, setSearchInputValue] = useState('');
@@ -202,7 +199,7 @@ const ViewPlan = () => {
           ) : (
             <div className='flex flex-col gap-6 rounded-2xl bg-white-100 p-6'>
               <ControlTab
-                type='sort'
+                isSortControl
                 controlTabItems={TAB_OPTIONS}
                 selectedTab={selectedTab}
                 setSelectedTab={setSelectedTab}

--- a/src/components/feature/ViewPlan/index.tsx
+++ b/src/components/feature/ViewPlan/index.tsx
@@ -7,6 +7,7 @@ import { MenuResponseDTO } from '@/type/menu/menuResponse';
 import { Result } from '@/type/response';
 // import { getCurrentYearMonthNow } from '@/utils/calendar';
 import { findOriginalId } from '@/utils/findOriginalId';
+import ControlTab from '@/components/common/ControlTab';
 import Pagination from '@/components/common/Pagination';
 import { Option } from '@/components/common/Selectbox';
 import { TableRowData } from '@/components/common/Table';
@@ -22,7 +23,6 @@ import { usePrefetchMinorCategories } from '@/hooks/menuCategory/usePrefetchMino
 import useNavigate from '@/hooks/useNavigate';
 import { useToastStore } from '@/stores/useToastStore';
 
-// TODO: constant 파일로 관리
 const PAGE_LIMIT = 8;
 const SORT_DESC = 'createdAt,desc';
 const SORT_ASC = 'createdAt,asc';
@@ -193,8 +193,6 @@ const ViewPlan = () => {
             setSelectedCategory={setSelectedCategory}
             searchValue={searchInputValue}
             handleChangeSearchValue={handleChangeSearchValue}
-            selectedTab={selectedTab}
-            setSelectedTab={setSelectedTab}
             inputPlaceholder='식단 이름을 입력해주세요.'
             handleSearchSubmit={submitSearchValue}
             minorCategories={minorCategories}
@@ -202,7 +200,13 @@ const ViewPlan = () => {
           {searchMealList?.data.totalElements === 0 ? (
             <HeadPrimary>식단이 존재하지 않습니다</HeadPrimary>
           ) : (
-            <>
+            <div className='flex flex-col gap-6 rounded-2xl bg-white-100 p-6'>
+              <ControlTab
+                type='sort'
+                controlTabItems={TAB_OPTIONS}
+                selectedTab={selectedTab}
+                setSelectedTab={setSelectedTab}
+              />
               <GetAllListTable
                 data={convertToTableRowData(
                   searchMealList?.data?.menuResponseDTOList ?? [],
@@ -215,7 +219,7 @@ const ViewPlan = () => {
                 setPage={setPage}
                 totalPosts={searchMealList?.data.totalElements ?? 0}
               />
-            </>
+            </div>
           )}
         </>
       )}

--- a/src/components/feature/ViewPlan/index.tsx
+++ b/src/components/feature/ViewPlan/index.tsx
@@ -113,8 +113,8 @@ const ViewPlan = () => {
 
   const convertToTableRowData = (menus: MenuResponseDTO[]): TableRowData[] => {
     return menus.map((menu) => ({
-      식단ID: menu.monthMenuId.slice(0, 4),
-      식단이름: menu.monthMenuName,
+      '식단 ID': menu.monthMenuId.slice(0, 4),
+      '식단 이름': menu.monthMenuName,
       대분류: menu.majorCategory,
       소분류: menu.minorCategory,
       생성일: dayjs(menu.createAt).format('YYYY-MM-DD'),
@@ -212,6 +212,7 @@ const ViewPlan = () => {
                   searchMealList?.data?.menuResponseDTOList ?? [],
                 )}
                 onRowClick={(id) => handleClickRow(String(id))}
+                headerType='viewPlan'
               />
               <Pagination
                 limit={PAGE_LIMIT}

--- a/src/components/shared/GetAllList/Controls/index.tsx
+++ b/src/components/shared/GetAllList/Controls/index.tsx
@@ -61,11 +61,11 @@ const GetAllListControls = ({
         )}
       >
         <Input
-          isLeftIcon={true}
+          isLeftIcon
           height='basic'
           placeholder={inputPlaceholder}
           bgcolor='meal'
-          includeButton={true}
+          includeButton
           value={searchValue}
           onChange={handleChangeSearchValue}
           onSubmit={handleSearchSubmit}

--- a/src/components/shared/GetAllList/Controls/index.tsx
+++ b/src/components/shared/GetAllList/Controls/index.tsx
@@ -1,12 +1,10 @@
 'use client';
 
 import { cn } from '@/utils/core';
-import ControlTab from '@/components/common/ControlTab';
 import DatePicker from '@/components/common/DatePicker';
 import { Input } from '@/components/common/Input';
 import { Option, Selectbox } from '@/components/common/Selectbox';
 import { ORGANIZATION_LIST } from '@/constants/_category';
-import { SURVEY_FILTER_OPTIONS, TAB_OPTIONS } from '@/constants/_controlTab';
 
 interface Props {
   type: 'viewPlan' | 'viewChart';
@@ -18,10 +16,6 @@ interface Props {
   setOrganization?: React.Dispatch<React.SetStateAction<string>>;
   searchValue: string;
   handleChangeSearchValue: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  selectedFilter?: string;
-  setSelectedFilter?: React.Dispatch<React.SetStateAction<string>>;
-  selectedTab: string;
-  setSelectedTab: React.Dispatch<React.SetStateAction<string>>;
   inputPlaceholder: string;
   handleSearchSubmit: () => void;
   minorCategories?: Option[];
@@ -39,10 +33,6 @@ const GetAllListControls = ({
   setOrganization,
   searchValue,
   handleChangeSearchValue,
-  selectedFilter,
-  setSelectedFilter,
-  selectedTab,
-  setSelectedTab,
   inputPlaceholder,
   handleSearchSubmit,
   minorCategories,
@@ -57,79 +47,53 @@ const GetAllListControls = ({
   };
 
   return (
-    <>
-      <div className='flex justify-between'>
-        <DatePicker
-          selectedMonth={selectedMonth}
-          selectedYear={selectedYear}
-          onMonthChange={onMonthChange}
-          onYearChange={onYearChange}
-        />
-        <div
-          className={cn(
-            'flex w-full items-end justify-end gap-5',
-            type === 'viewChart' && 'w-1/2',
-          )}
-        >
-          <Input
-            isLeftIcon={true}
-            height='basic'
-            placeholder={inputPlaceholder}
-            bgcolor='meal'
-            includeButton={true}
-            value={searchValue}
-            onChange={handleChangeSearchValue}
-            onSubmit={handleSearchSubmit}
-          />
-          {type === 'viewPlan' && setOrganization && setSelectedCategory && (
-            <div className='flex gap-1 whitespace-pre'>
-              <Selectbox
-                options={ORGANIZATION_LIST}
-                size='small'
-                onChange={handleOrganizationChange}
-                selectedValue={organization}
-              />
-              {ORGANIZATION_LIST.map(
-                (item) =>
-                  organization === item.value && (
-                    <Selectbox
-                      key={item.value}
-                      options={minorCategories}
-                      size='small'
-                      onChange={(category) => setSelectedCategory(category)}
-                      selectedValue={selectedCategory}
-                    />
-                  ),
-              )}
-            </div>
-          )}
-        </div>
-      </div>
-      <div className='flex items-center justify-end gap-3'>
-        {type === 'viewChart' && (
-          <>
-            <ControlTab
-              controlTabItems={SURVEY_FILTER_OPTIONS}
-              selectedFilter={selectedFilter!}
-              setSelectedFilter={setSelectedFilter!}
-              selectedTab={selectedTab}
-              setSelectedTab={setSelectedTab}
-            />
-            <span className='mx-1 h-4 cursor-default text-xs text-gray-500'>
-              |
-            </span>
-          </>
+    <div className='flex justify-between'>
+      <DatePicker
+        selectedMonth={selectedMonth}
+        selectedYear={selectedYear}
+        onMonthChange={onMonthChange}
+        onYearChange={onYearChange}
+      />
+      <div
+        className={cn(
+          'flex w-full items-end justify-end gap-5',
+          type === 'viewChart' && 'w-1/2',
         )}
-        <ControlTab
-          type='sort'
-          controlTabItems={TAB_OPTIONS}
-          selectedFilter={selectedFilter!}
-          setSelectedFilter={setSelectedFilter!}
-          selectedTab={selectedTab}
-          setSelectedTab={setSelectedTab}
+      >
+        <Input
+          isLeftIcon={true}
+          height='basic'
+          placeholder={inputPlaceholder}
+          bgcolor='meal'
+          includeButton={true}
+          value={searchValue}
+          onChange={handleChangeSearchValue}
+          onSubmit={handleSearchSubmit}
         />
+        {type === 'viewPlan' && setOrganization && setSelectedCategory && (
+          <div className='flex gap-1 whitespace-pre'>
+            <Selectbox
+              options={ORGANIZATION_LIST}
+              size='small'
+              onChange={handleOrganizationChange}
+              selectedValue={organization}
+            />
+            {ORGANIZATION_LIST.map(
+              (item) =>
+                organization === item.value && (
+                  <Selectbox
+                    key={item.value}
+                    options={minorCategories}
+                    size='small'
+                    onChange={(category) => setSelectedCategory(category)}
+                    selectedValue={selectedCategory}
+                  />
+                ),
+            )}
+          </div>
+        )}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/shared/GetAllList/ListTable/index.tsx
+++ b/src/components/shared/GetAllList/ListTable/index.tsx
@@ -3,10 +3,18 @@ import Table, { TableRowData } from '@/components/common/Table';
 interface Props {
   data: TableRowData[];
   onRowClick?: (id: number | string) => void;
+  headerType: 'viewPlan' | 'viewChart';
 }
 
-const GetAllListTable = ({ data, onRowClick }: Props) => {
-  return <Table data={data} type='list' onRowClick={onRowClick} />;
+const GetAllListTable = ({ headerType, data, onRowClick }: Props) => {
+  return (
+    <Table
+      data={data}
+      type='list'
+      onRowClick={onRowClick}
+      headerType={headerType}
+    />
+  );
 };
 
 export default GetAllListTable;

--- a/src/components/shared/GetAllList/ListTable/index.tsx
+++ b/src/components/shared/GetAllList/ListTable/index.tsx
@@ -3,7 +3,7 @@ import Table, { TableRowData } from '@/components/common/Table';
 interface Props {
   data: TableRowData[];
   onRowClick?: (id: number | string) => void;
-  headerType: 'viewPlan' | 'viewChart';
+  headerType?: 'viewPlan' | 'viewChart';
 }
 
 const GetAllListTable = ({ headerType, data, onRowClick }: Props) => {
@@ -12,7 +12,7 @@ const GetAllListTable = ({ headerType, data, onRowClick }: Props) => {
       data={data}
       type='list'
       onRowClick={onRowClick}
-      headerType={headerType}
+      headerType={headerType!}
     />
   );
 };

--- a/src/constants/_pagination.ts
+++ b/src/constants/_pagination.ts
@@ -2,3 +2,6 @@ export const CAL_PAGE_NUM = {
   FIRST_PAGE: 4,
   LAST_PAGE: 1,
 };
+
+export const PAGE_LIMIT = 10;
+export const DEFAULT_PAGE = 1;


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- Table, TableBody, TableHeader 컴포넌트 리디자인 적용
- Pagination 페이지 1개일때의 스타일 수정
- ControlTab 컴포넌트 ListControls 컴포넌트에서 ViewPlan, ViewChart 각 컴포넌트로 이동

## 스크린샷

![image](https://github.com/user-attachments/assets/bd99211c-edb3-4988-8a6b-6ba2925392ec)

![image](https://github.com/user-attachments/assets/bbd4ecfb-18eb-4e33-8f06-90fba7815f1e)


## 리뷰 요구사항

- 식단/설문 테이블별로, cols별로 고정된 너비가 모두 달라서 식단, 설문에 대한 테이블은 ```planHeaderStyles``` ```surveyHeaderStyles``` 로 선언해서 각 header마다 디자인된 너비를 주었습니다!
- 영양정보 테이블도 똑같이 headerStyles 선언해서 각 cols마다 너비를 지정해주시고 사용하면 될 것 같습니다
