### PR TITLE
Fix[THKV-117]: Typography color variants 수정

### DIFF
--- a/src/components/common/Typography/Typography.variant.tsx
+++ b/src/components/common/Typography/Typography.variant.tsx
@@ -49,15 +49,24 @@ export const typographyVariants = cva('whitespace-pre-line text-wrap', {
       normal: 'font-normal',
     },
     color: {
+      black: 'text-black-100',
       white: 'text-white-100',
+      green: 'text-green-500',
+      blue: 'text-blue-500',
+      red: 'text-red-500',
+      grey100: 'text-grey-100',
+      grey200: 'text-grey-200',
+      grey500: 'text-grey-500',
+      grey900: 'text-grey-900',
+
+      // 리디자인 후 삭제
       darken: 'text-dark-200',
       dark: 'text-dark-100',
       gray: 'text-gray-500',
-      black: 'text-black-100',
     },
   },
   defaultVariants: {
-    type: 'body3',
-    color: 'dark',
+    type: 'Body3',
+    color: 'black',
   },
 });

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -3,7 +3,7 @@
 import { ComponentPropsWithoutRef, ElementType } from 'react';
 import { VariantProps } from 'class-variance-authority';
 import { cn } from '@/utils/core';
-import { typographyVariants } from './Typography.variant';
+import { typographyVariants } from '@/components/common/Typography/Typography.variant';
 
 export type TypographyProps = VariantProps<typeof typographyVariants> &
   ComponentPropsWithoutRef<'p'>;
@@ -25,17 +25,17 @@ const customTypography = (
 
 export const ControlTabTypo = customTypography('span', {
   type: 'Body3',
-  color: 'gray',
+  color: 'grey500',
 });
 
 export const TableHeaderTypo = customTypography('span', {
   type: 'label1',
-  color: 'dark',
+  color: 'black',
 });
 
 export const TableBodyTypo = customTypography('span', {
   type: 'Body2',
-  color: 'dark',
+  color: 'black',
 });
 
 export const InfoCardTypo = customTypography('span', {


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [x] UI 구현
- [ ] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- Typography color variants 네이밍 수정


## 리뷰 요구사항

- color variants 네이밍을 grey의 컬러들이 다양하게 쓰여서 ```grey100```, ```grey200``` 이런식으로 정의해두었는데
다른 좋은 방법 있으시면 말씀해주세여! 
