### PR TITLE
Fix[THKV-123]: Table rowClick 함수 호출되지 않는 버그 수정

### DIFF
--- a/src/components/common/TableBody/index.tsx
+++ b/src/components/common/TableBody/index.tsx
@@ -42,10 +42,12 @@ const TableBody = ({
           key={rowIndex}
           className={cn('h-16 cursor-pointer odd:bg-grey-50 hover:bg-grey-100')}
           onClick={
-            onRowClick && type === 'list' && typeof item.설문ID === 'number'
-              ? () => onRowClick(item.설문ID as number)
-              : onRowClick && type === 'list' && typeof item.식단ID === 'string'
-                ? () => onRowClick(item.식단ID as string)
+            onRowClick && type === 'list' && typeof item['설문 ID'] === 'number'
+              ? () => onRowClick(item['설문 ID'] as number)
+              : onRowClick &&
+                  type === 'list' &&
+                  typeof item['식단 ID'] === 'string'
+                ? () => onRowClick(item['식단 ID'] as string)
                 : undefined
           }
         >


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 테이블 리팩토링 후 rowClick 함수가 호출되지 않는 버그 수정

### 설명 (선택)

- TableBody 컴포넌트의 ```planHeaderStyles``` 객체와 ```surveyHeaderStyles``` 객체의 키값을 테이블헤더 포맷팅때문에 수정을 했었는데, rowClick함수의 매개변수에 들어가는 키값도 함께 수정했습니다
