### PR TITLE
Feat[THKV-128] : Typography 충돌 해결, ProfileImage 구현

### DIFF
--- a/src/components/common/NavProfile/index.tsx
+++ b/src/components/common/NavProfile/index.tsx
@@ -1,15 +1,12 @@
 import Icon from '@/components/common/Icon';
+import ProfileImage from '@/components/common/ProfileImage';
 import { Body2Black, Subtitle2Black } from '@/components/common/Typography';
 
 const NavProfile = ({ name = '냠냠' }: { name: string }) => {
   return (
     <button className='flex w-[238px] items-center justify-between gap-2'>
-      {/* TODO: 추후 컴포넌트 제작, 이미지 변경 필요 */}
-      {/* <Badge
-        imageSrc='/imgs/pi-gon-ping.jpg'
-        size={40}
-        className='border border-grey-100'
-      /> */}
+      {/* TODO: 프로필 이미지 변경 필요 */}
+      <ProfileImage src='/imgs/pi-gon-ping.jpg' size={40} />
       <div className='flex items-center justify-center gap-2'>
         <Body2Black>다시 만나 기뻐요!</Body2Black>
         <Subtitle2Black>{name}님</Subtitle2Black>

--- a/src/components/common/ProfileImage/index.tsx
+++ b/src/components/common/ProfileImage/index.tsx
@@ -1,0 +1,36 @@
+import Image from 'next/image';
+import { cn } from '@/utils/core';
+
+const DEFAULT_PROFILE_IMAGE = '/imgs/pi-gon-ping.jpg';
+
+type Props = {
+  src: string;
+  size: number;
+  alt?: string;
+  className?: string;
+};
+
+const ProfileImage = ({
+  src,
+  size,
+  alt = 'Profile Image',
+  className,
+}: Props) => {
+  return (
+    <div
+      className={cn(
+        'h-fit w-fit min-w-9 overflow-hidden rounded-full border border-grey-100',
+        className,
+      )}
+    >
+      <Image
+        src={src || DEFAULT_PROFILE_IMAGE}
+        width={size}
+        height={size}
+        alt={alt}
+      />
+    </div>
+  );
+};
+
+export default ProfileImage;

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -108,11 +108,6 @@ export const Subtitle2Red500 = customTypography('span', {
   color: 'red',
 });
 
-export const Body3Black = customTypography('span', {
-  type: 'Body3',
-  color: 'black',
-});
-
 // 리디자인 변경 전 Typography
 export const HeadPrimary = customTypography('h1', {
   type: 'heading1',

--- a/src/components/feature/MyPage/index.tsx
+++ b/src/components/feature/MyPage/index.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Image from 'next/image';
+// import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -15,6 +15,7 @@ import { findOriginalId } from '@/utils/findOriginalId';
 import Button from '@/components/common/Button/Button';
 import { Input } from '@/components/common/Input';
 import Modal from '@/components/common/Modal';
+import ProfileImage from '@/components/common/ProfileImage';
 import { TableRowData } from '@/components/common/Table';
 import {
   BodyGray,
@@ -35,7 +36,7 @@ import { useToastStore } from '@/stores/useToastStore';
 import { useUserStore } from '@/stores/useUserStore';
 
 const imageInfo = {
-  size: 110,
+  size: 96,
   src: '/imgs/pi-gon-ping.jpg',
 };
 
@@ -272,13 +273,14 @@ const MyPage = () => {
       <div className='flex flex-col'>
         <div className='mb-10 flex w-full'>
           <div className='flex w-full items-center gap-4 border-r-2 border-gray-200 border-opacity-50 px-16'>
-            <Image
+            <ProfileImage src={imageInfo.src} size={imageInfo.size} />
+            {/* <Image
               src={imageInfo.src}
               width={imageInfo.size}
               height={imageInfo.size}
               alt='유저 이미지'
               className='rounded-full'
-            />
+            /> */}
             <div className='flex flex-col gap-1'>
               <div className='flex items-center gap-2'>
                 <CardTitle>{isMounted ? username : ''}</CardTitle> 님


### PR DESCRIPTION
<!--
제목은 `Feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) Feat[#THKV-108]: 버튼 컴포넌트 기능 구현
-->

## 유형

- [x] 기능 구현
- [ ] UI 구현
- [x] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

1. Typography - Body3Black 중복 선언으로 인한 에러 해결
2. ProfileImage 구현
3. NavProfile, MyPage에 ProfileImage 적용

### 설명 (선택)

- origin dev 풀받고 보니까 Typography에서 오류가 나더라고요. 머지할 때는 컨플릭 없었는데 런타임에서 컴포넌트 중복선언했다고 오류 나서 두번째로 Body3Black 선언한거 삭제했습니다
- ProfileImage 컴포넌트 적용한건 아래 사진 보시면 됩니다~ 마이페이지에서 Image 태그 그대로 썼던 부분은 주석처리해두었어요
## 스크린샷
### 1. nav
<img width="283" alt="image" src="https://github.com/user-attachments/assets/9c1b050b-ee15-4c92-ba10-813ad6ef4534" />

### 2. mypage
<img width="706" alt="image" src="https://github.com/user-attachments/assets/32e65464-4c22-420f-b3b6-d91e5498e6b4" />

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->

## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->

-
