### PR TITLE
Feat[THKV-136]: 설문 수정페이지, 삭제모달, qrcode파트 작업

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "dayjs": "^1.11.13",
         "next": "14.2.6",
         "nookies": "^2.5.2",
+        "qrcode.react": "^4.2.0",
         "react": "^18",
         "react-apexcharts": "^1.5.0",
         "react-datepicker": "^7.4.0",
@@ -643,13 +644,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.4.tgz",
       "integrity": "sha512-J7W30FTdfCxDDjmfRM+/JqLHBIyl7xUIp9kwK637FGmY7+mkSFSe6L4jpZzhj5QMfLssSDP4/i75AKkrdC7/Jw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1651,7 +1652,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -4911,6 +4912,15 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dayjs": "^1.11.13",
     "next": "14.2.6",
     "nookies": "^2.5.2",
+    "qrcode.react": "^4.2.0",
     "react": "^18",
     "react-apexcharts": "^1.5.0",
     "react-datepicker": "^7.4.0",

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -44,7 +44,10 @@ const Modal = ({ children }: ModalProps) => {
 
   return (
     <div className='fixed inset-0 z-50 flex items-center justify-center bg-dimmed'>
-      <div ref={modalRef} className='left-1/2 top-1/2'>
+      <div
+        ref={modalRef}
+        className='left-1/2 top-1/2 rounded-2xl bg-white-100 p-6'
+      >
         {children}
       </div>
     </div>

--- a/src/components/common/Typography/index.tsx
+++ b/src/components/common/Typography/index.tsx
@@ -108,6 +108,11 @@ export const SubTitle1Green500 = customTypography('span', {
   color: 'green',
 });
 
+export const Subtitle1White = customTypography('span', {
+  type: 'Subtitle1',
+  color: 'white',
+});
+
 export const Subtitle2Black = customTypography('span', {
   type: 'Subtitle2',
   color: 'black',

--- a/src/components/feature/ChartDetail/index.tsx
+++ b/src/components/feature/ChartDetail/index.tsx
@@ -9,12 +9,14 @@ import { Question } from '@/type/survey/surveyResponse';
 import { getTextResponsesByQuestionText } from '@/utils/getTextResponseByQuestionText';
 import Button from '@/components/common/Button/Button';
 import DatepickerCalendar from '@/components/common/DatepickerCalendar';
+import Modal from '@/components/common/Modal';
 import {
   Body2Assistive,
   Body2Black,
   Body3Assistive,
   H2Black,
   SubTitle1Black,
+  Subtitle1White,
   Subtitle2Black,
   Subtitle2Green500,
   Subtitle2Grey100,
@@ -30,6 +32,7 @@ import { surveyKeys } from '@/hooks/survey/queryKey';
 import { useDeleteSurvey } from '@/hooks/survey/useDeleteSurvey';
 import { useGetSurveyDetail } from '@/hooks/survey/useGetSurveyDetail';
 import useNavigate from '@/hooks/useNavigate';
+import { useModalStore } from '@/stores/modalStore';
 import { useToastStore } from '@/stores/useToastStore';
 
 interface Props {
@@ -41,14 +44,17 @@ const ChartDetail = ({ id }: Props) => {
   const { navigate } = useNavigate();
   const queryClient = useQueryClient();
   const showToast = useToastStore((state) => state.showToast);
+  const { closeModal, isOpen, openModal } = useModalStore();
 
   const { mutate: deleteSurveyMutate } = useDeleteSurvey({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: surveyKeys.lists() });
+      closeModal();
       router.push(NAV_LINKS[4].href);
       showToast('설문 삭제 성공', 'success', 1000);
     },
     onError: (error: AxiosError<FailResponse>) => {
+      closeModal();
       const errorMessage = error.response?.data.message || '설문 삭제 실패';
       showToast(errorMessage, 'warning', 1000);
     },
@@ -60,7 +66,7 @@ const ChartDetail = ({ id }: Props) => {
     detailData || {};
 
   const deleteHandler = () => {
-    deleteSurveyMutate(id);
+    openModal();
   };
 
   const isAllDistributionZero = (distribution: Question) => {
@@ -96,139 +102,171 @@ const ChartDetail = ({ id }: Props) => {
   };
 
   return (
-    <div className='flex flex-col gap-10'>
-      {detailData &&
-        averageScores &&
-        mandatoryQuestions &&
-        additionalQuestions && (
+    <>
+      {isOpen && (
+        <Modal>
           <div className='flex flex-col gap-6'>
-            <H2Black>{surveyName}</H2Black>
-            <div className='flex items-center justify-between'>
-              <DatepickerCalendar
-                deadLine={dayjs(detailData.deadline).format(
-                  'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
-                )}
-                isChangeable={false}
-              />
-              <div className='flex h-12 gap-2'>
-                <Button variant='secondary' size='sm'>
-                  <Subtitle2Green500>설문 종료</Subtitle2Green500>
-                </Button>
-                <Button
-                  variant='teritary'
-                  size='sm'
-                  onClick={() => navigate(`${ROUTES.SURVEY.EDIT}/${id}`)}
-                >
-                  <Subtitle2Grey100>질문 수정</Subtitle2Grey100>
-                </Button>
-                <Button variant='grey' size='sm' onClick={deleteHandler}>
-                  <Subtitle2Grey900>설문 삭제</Subtitle2Grey900>
-                </Button>
-              </div>
+            <div className='flex flex-col gap-4'>
+              <SubTitle1Black>설문 삭제</SubTitle1Black>
+              <Body2Black>진행 중인 설문을 삭제하시겠습니까?</Body2Black>
             </div>
-            <div className='flex h-[336px] w-full gap-6'>
-              <div className='flex h-full w-full max-w-[1056px] flex-col gap-6 rounded-2xl bg-white-100 p-6'>
-                <SubTitle1Black>월별 총 만족도 점수 분포도</SubTitle1Black>
-                {mandatoryQuestions!.every(isAllDistributionZero) ? (
-                  <div className='flex min-h-[130px] w-full items-center justify-center'>
-                    <Body2Assistive>제출된 설문이 없습니다.</Body2Assistive>
-                  </div>
-                ) : (
-                  <div className='h-full w-[1008px]'>
-                    <BarGraph data={mandatoryQuestions![0].radioResponses} />
-                  </div>
-                )}
-              </div>
-              <div className='flex h-full w-[516px] flex-col gap-4 rounded-2xl bg-white-100 p-6'>
-                <SubTitle1Black>만족도 평균</SubTitle1Black>
-                {!Object.values(averageScores).every((score) => score === 0) ? (
-                  <div className='h-full w-full'>
-                    <AverageGraph averageScores={averageScores} />
-                  </div>
-                ) : (
-                  <div className='flex min-h-[130px] w-full items-center justify-center'>
-                    <Body2Assistive>제출된 설문이 없습니다.</Body2Assistive>
-                  </div>
-                )}
-              </div>
+            <div className='flex w-full gap-2'>
+              <Button
+                variant='grey'
+                size='md'
+                width='full'
+                onClick={() => closeModal()}
+              >
+                <SubTitle1Black>취소</SubTitle1Black>
+              </Button>
+              <Button
+                variant='primary'
+                size='md'
+                width='full'
+                onClick={() => deleteSurveyMutate(id)}
+              >
+                <Subtitle1White>삭제</Subtitle1White>
+              </Button>
             </div>
-            <div className='flex w-full gap-6'>
-              <TopCard
-                title='식단 좋아요 Top3'
-                type='like'
-                top3Data={getTextResponsesByQuestionText(
-                  mandatoryQuestions,
-                  '가장 좋아하는 상위 3개 식단',
-                )}
-              />
-              <TopCard
-                title='식단 싫어요 Top3'
-                type='unlike'
-                top3Data={getTextResponsesByQuestionText(
-                  mandatoryQuestions,
-                  '가장 싫어하는 상위 3개 식단',
-                )}
-              />
-            </div>
-            <div className='flex w-full gap-6'>
-              <TextList
-                type='desireMenu'
-                list={
-                  getTextResponsesByQuestionText(
-                    mandatoryQuestions,
-                    '먹고 싶은 메뉴',
-                  )!
-                }
-                title='먹고 싶은 메뉴'
-              />
-              <TextList
-                type='desireMenu'
-                list={
-                  getTextResponsesByQuestionText(
-                    mandatoryQuestions,
-                    '영양사에게 한마디',
-                  )!
-                }
-                title='영양사에게 한마디'
-              />
-              <div className='flex w-full flex-col gap-6 rounded-2xl bg-white-100 p-6'>
-                <SubTitle1Black>설문 조사 링크</SubTitle1Black>
-                <div className='flex w-full items-center gap-6'>
-                  <QrCodeCanvas id={id} />
-                  <div className='flex w-full flex-col gap-4'>
-                    <div className='flex flex-col gap-2'>
-                      <Body3Assistive>
-                        QR 코드를 다운로드하거나 URL을 복사하여
-                        <br />
-                        작성한 설문을 간편하게 공유하세요!
-                      </Body3Assistive>
-                      <Body2Black>{`${BASE_DOMAIN}${ROUTES.SURVEY.TAKE}/${id}`}</Body2Black>
+          </div>
+        </Modal>
+      )}
+      <div className='flex flex-col gap-10'>
+        {detailData &&
+          averageScores &&
+          mandatoryQuestions &&
+          additionalQuestions && (
+            <div className='flex flex-col gap-6'>
+              <H2Black>{surveyName}</H2Black>
+              <div className='flex items-center justify-between'>
+                <DatepickerCalendar
+                  deadLine={dayjs(detailData.deadline).format(
+                    'YYYY-MM-DDTHH:mm:ss.SSS[Z]',
+                  )}
+                  isChangeable={false}
+                />
+                <div className='flex h-12 gap-2'>
+                  <Button variant='secondary' size='sm'>
+                    <Subtitle2Green500>설문 종료</Subtitle2Green500>
+                  </Button>
+                  <Button
+                    variant='teritary'
+                    size='sm'
+                    onClick={() => navigate(`${ROUTES.SURVEY.EDIT}/${id}`)}
+                  >
+                    <Subtitle2Grey100>질문 수정</Subtitle2Grey100>
+                  </Button>
+                  <Button variant='grey' size='sm' onClick={deleteHandler}>
+                    <Subtitle2Grey900>설문 삭제</Subtitle2Grey900>
+                  </Button>
+                </div>
+              </div>
+              <div className='flex h-[336px] w-full gap-6'>
+                <div className='flex h-full w-full max-w-[1056px] flex-col gap-6 rounded-2xl bg-white-100 p-6'>
+                  <SubTitle1Black>월별 총 만족도 점수 분포도</SubTitle1Black>
+                  {mandatoryQuestions!.every(isAllDistributionZero) ? (
+                    <div className='flex min-h-[130px] w-full items-center justify-center'>
+                      <Body2Assistive>제출된 설문이 없습니다.</Body2Assistive>
                     </div>
-                    <div className='flex w-full gap-2'>
-                      <Button
-                        variant='outline'
-                        size='xs'
-                        width='full'
-                        onClick={downloadQRCode}
-                      >
-                        <Subtitle2Black>QR 코드 다운로드</Subtitle2Black>
-                      </Button>
-                      <Button
-                        variant='outline'
-                        size='xs'
-                        width='full'
-                        onClick={copyQRcode}
-                      >
-                        <Subtitle2Black>URL 복사</Subtitle2Black>
-                      </Button>
+                  ) : (
+                    <div className='h-full w-[1008px]'>
+                      <BarGraph data={mandatoryQuestions![0].radioResponses} />
+                    </div>
+                  )}
+                </div>
+                <div className='flex h-full w-[516px] flex-col gap-4 rounded-2xl bg-white-100 p-6'>
+                  <SubTitle1Black>만족도 평균</SubTitle1Black>
+                  {!Object.values(averageScores).every(
+                    (score) => score === 0,
+                  ) ? (
+                    <div className='h-full w-full'>
+                      <AverageGraph averageScores={averageScores} />
+                    </div>
+                  ) : (
+                    <div className='flex min-h-[130px] w-full items-center justify-center'>
+                      <Body2Assistive>제출된 설문이 없습니다.</Body2Assistive>
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className='flex w-full gap-6'>
+                <TopCard
+                  title='식단 좋아요 Top3'
+                  type='like'
+                  top3Data={getTextResponsesByQuestionText(
+                    mandatoryQuestions,
+                    '가장 좋아하는 상위 3개 식단',
+                  )}
+                />
+                <TopCard
+                  title='식단 싫어요 Top3'
+                  type='unlike'
+                  top3Data={getTextResponsesByQuestionText(
+                    mandatoryQuestions,
+                    '가장 싫어하는 상위 3개 식단',
+                  )}
+                />
+              </div>
+              <div className='flex w-full gap-6'>
+                <TextList
+                  type='desireMenu'
+                  list={
+                    getTextResponsesByQuestionText(
+                      mandatoryQuestions,
+                      '먹고 싶은 메뉴',
+                    )!
+                  }
+                  title='먹고 싶은 메뉴'
+                />
+                <TextList
+                  type='desireMenu'
+                  list={
+                    getTextResponsesByQuestionText(
+                      mandatoryQuestions,
+                      '영양사에게 한마디',
+                    )!
+                  }
+                  title='영양사에게 한마디'
+                />
+                <div className='flex w-full flex-col gap-6 rounded-2xl bg-white-100 p-6'>
+                  <SubTitle1Black>설문 조사 링크</SubTitle1Black>
+                  <div className='flex w-full items-center gap-6'>
+                    <QrCodeCanvas id={id} />
+                    <div className='flex w-full flex-col gap-4'>
+                      <div className='flex flex-col gap-2'>
+                        <Body3Assistive>
+                          QR 코드를 다운로드하거나 URL을 복사하여
+                          <br />
+                          작성한 설문을 간편하게 공유하세요!
+                        </Body3Assistive>
+                        <Body2Black>{`${BASE_DOMAIN}${ROUTES.SURVEY.TAKE}/${id}`}</Body2Black>
+                      </div>
+                      <div className='flex w-full gap-2'>
+                        <Button
+                          variant='outline'
+                          size='xs'
+                          width='full'
+                          onClick={downloadQRCode}
+                        >
+                          <Subtitle2Black>QR 코드 다운로드</Subtitle2Black>
+                        </Button>
+                        <Button
+                          variant='outline'
+                          size='xs'
+                          width='full'
+                          onClick={copyQRcode}
+                        >
+                          <Subtitle2Black>URL 복사</Subtitle2Black>
+                        </Button>
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
-    </div>
+          )}
+      </div>
+    </>
   );
 };
 

--- a/src/components/feature/Survey/Edit/index.tsx
+++ b/src/components/feature/Survey/Edit/index.tsx
@@ -87,7 +87,7 @@ const SurveyEdit = ({ id }: Props) => {
           <AdditionQuestions
             inputs={inputs}
             setInputs={setInputs}
-            successSubmit={true}
+            successSubmit={false}
           />
         </div>
       </div>

--- a/src/components/shared/Survey/Controls/index.tsx
+++ b/src/components/shared/Survey/Controls/index.tsx
@@ -34,10 +34,10 @@ const SurveyControls = ({
 
   const handleChangeSurveyName = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.value.length <= EXTRA_SURVEYNAME_LIMIT && !isChangeable) {
-      setEditSurveyName!(e.target.value);
+      setSurveyName!(e.target.value);
     }
     if (e.target.value.length <= EXTRA_SURVEYNAME_LIMIT && isChangeable) {
-      setSurveyName!(e.target.value);
+      setEditSurveyName!(e.target.value);
     }
   };
 

--- a/src/components/shared/Survey/QrCodeCanvas.tsx
+++ b/src/components/shared/Survey/QrCodeCanvas.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import React from 'react';
 import { QRCodeCanvas } from 'qrcode.react';
 import { BASE_DOMAIN, ROUTES } from '@/constants/_navbar';
 

--- a/src/components/shared/Survey/QrCodeCanvas.tsx
+++ b/src/components/shared/Survey/QrCodeCanvas.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import React from 'react';
+import { QRCodeCanvas } from 'qrcode.react';
+import { BASE_DOMAIN, ROUTES } from '@/constants/_navbar';
+
+const QrCodeCanvas = ({ id }: { id: number }) => {
+  const router = useRouter();
+
+  return (
+    <QRCodeCanvas
+      size={144}
+      id='qrcode'
+      className='rounded-lg border border-grey-100 p-6'
+      onClick={() => router.push(`${ROUTES.SURVEY.TAKE}/${id}`)}
+      value={`${BASE_DOMAIN}${ROUTES.SURVEY.TAKE}/${id}`}
+    />
+  );
+};
+
+export default QrCodeCanvas;

--- a/src/constants/_navbar.ts
+++ b/src/constants/_navbar.ts
@@ -1,3 +1,4 @@
+export const BASE_DOMAIN = 'https://www.nnplanner.com';
 export const BASE_ROUTES = {
   MAIN: '/main',
   AUTO: '/autoPlan',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { AUTH_LINKS } from '@/constants/_auth';
-import { NAV_LINKS } from '@/constants/_navbar';
+import { NAV_LINKS, ROUTES } from '@/constants/_navbar';
 
 export const config = {
   matcher: [
@@ -8,7 +8,7 @@ export const config = {
   ],
 };
 
-const publicRoutes = [AUTH_LINKS.signup, AUTH_LINKS.login];
+const publicRoutes = [AUTH_LINKS.signup, AUTH_LINKS.login, ROUTES.SURVEY.TAKE];
 
 export function middleware(request: NextRequest) {
   const isLogin = request.cookies.get('isLogin');


### PR DESCRIPTION
## 유형

- [x] 기능 구현
- [x] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 설문 수정페이지 리디자인 적용
- 설문 삭제 모달 적용
- qrcode 파트 작업

### 설명 (선택)

- qrcode는 기존 사용하고자했던 api가 텍스트 저장용으로 파악되어 qrcode.react 라이브러리 사용했습니다
- QR코드 다운로드 버튼 클릭시 png형식으로 qrcode가 다운로드 됩니다

## 스크린샷

![522322222](https://github.com/user-attachments/assets/99f409a8-228d-4d55-8634-5aeaacdebb87)

![412322](https://github.com/user-attachments/assets/727f3313-97d4-4229-bdad-7578878e7195)

![52222](https://github.com/user-attachments/assets/58939186-3520-43ee-b0e3-2e1c5194e4af)


## 리뷰 요구사항

- 일단 로컬상에서 qrcode 핸드폰으로 찍어서 nnplanner로 타고 들어가는건 확인했는데, 미들웨어 때문에 login페이지로 리다이렉트 되어 정확히 설문 응답페이지로 이동하는지는 머지 후 체크가능해 보입니다!
- 머지 후 풀 받으시고 ```npm i``` 한번 부탁드립니다!

