### PR TITLE
fix[THKV-141] : AutoPlan - infocard 중복 렌더 해결

### DIFF
--- a/src/components/feature/AutoPlan/index.tsx
+++ b/src/components/feature/AutoPlan/index.tsx
@@ -9,11 +9,9 @@ import {
 } from '@/type/menuCategory/category';
 import { FailResponse, Result } from '@/type/response';
 import { getCurrentYearMonthNow, getLastDateOfMonth } from '@/utils/calendar';
-import InfoCard from '@/components/common/InfoCard';
 import MealForm from '@/components/common/MealForm';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
 import MealHeader from '@/components/shared/Meal/MealHeader';
-import { INFOCARD_MESSAGE } from '@/constants/_infoCard';
 import { MEAL_FORM_LEGEND } from '@/constants/_MealForm';
 import { ROUTES } from '@/constants/_navbar';
 import { PAGE_TITLE } from '@/constants/_pageTitle';
@@ -117,10 +115,6 @@ const AutoPlan = () => {
           readonly={true}
         />
       </MealForm>
-      <div className='flex w-full flex-col gap-4 pt-[142px]'>
-        <InfoCard message={INFOCARD_MESSAGE.autoPlan.name} />
-        <InfoCard message={INFOCARD_MESSAGE.autoPlan.category} />
-      </div>
     </div>
   );
 };


### PR DESCRIPTION
<!--
제목은 `Feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) Feat[#THKV-108]: 버튼 컴포넌트 기능 구현
-->

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

- infocard 중복 렌더 해결
- x 스크롤이 있는 걸 인지를 못하고 info card가 두 번 렌더링된걸 못본 것 같습니다. 수정했어요

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/89a14bca-1d5b-4621-a454-e5bc807b020c" />

