### PR TITLE
Fix[THKV-154]: 추가질문 인덱싱 수정

### DIFF
--- a/src/components/feature/Survey/Take/index.tsx
+++ b/src/components/feature/Survey/Take/index.tsx
@@ -226,7 +226,7 @@ const SurveyTake = ({ id }: Props) => {
               className='flex w-full flex-col gap-4'
             >
               <li className='flex items-center gap-1'>
-                <Body2Black>{idx + 1}. </Body2Black>
+                <Body2Black>{idx + 9}. </Body2Black>
                 <Body2Black>{question.questionText}</Body2Black>
               </li>
               {question.answerType === 'text' && (


### PR DESCRIPTION
## 유형

- [ ] 기능 구현
- [x] UI 구현
- [x] 리팩토링
- [ ] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

- 설문 응답 페이지 추가질문 인덱싱 수정

### 설명 (선택)

- 추가질문부터 다시 1번으로 시작되는 인덱싱에서 9번 이후로 시작되는 인덱싱으로 수정

## 스크린샷

![image](https://github.com/user-attachments/assets/27fb02a7-240a-42c6-aa95-7ae7f4a9b298)

