### PR TITLE
Fix[#156] : 대분류 '학교' 선택 시 소분류에 '초/중/고'만 보이도록 옵션 수정, 식단 헤더 gap 수정

### DIFF
--- a/src/api/menuCategory/index.ts
+++ b/src/api/menuCategory/index.ts
@@ -6,6 +6,9 @@ import { MENU_CAGEGORY_API } from '@/constants/_apiPath';
 
 const { MENU_CATEGORIES, SEARCH_SCHOOL } = MENU_CAGEGORY_API;
 
+/**
+ * @description 소분류 조회
+ */
 const getMinorCategories = async (param: MajorCategory) => {
   const response = await get<Result<string[] | null>>(MENU_CATEGORIES, {
     params: {
@@ -16,7 +19,7 @@ const getMinorCategories = async (param: MajorCategory) => {
 };
 
 /**
- * @description 학교명 검색 api
+ * @description 학교명 검색
  */
 const getSearchSchool = async ({ keyword }: GetSearchSchoolRequest) => {
   const response = await get<Result<string[] | []>>(SEARCH_SCHOOL, {

--- a/src/components/feature/AutoPlan/index.tsx
+++ b/src/components/feature/AutoPlan/index.tsx
@@ -279,8 +279,8 @@ const AutoPlan = () => {
                   selectedValue={selectedCategory.majorCategory}
                   isError={isCategoryError}
                 />
-                <div className='relative'>
-                  {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+                {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+                  <div className='relative'>
                     <div className='flex gap-4'>
                       <Input
                         variant='white'
@@ -299,15 +299,15 @@ const AutoPlan = () => {
                         <Subtitle2White>검색</Subtitle2White>
                       </Button>
                     </div>
-                  )}
-                  <Dropdown isOpen={isOpen} className='top-12'>
-                    <OptionList
-                      options={options}
-                      onSelect={handleSchoolNameSelect}
-                      size='basic'
-                    />
-                  </Dropdown>
-                </div>
+                    <Dropdown isOpen={isOpen} className='top-12'>
+                      <OptionList
+                        options={options}
+                        onSelect={handleSchoolNameSelect}
+                        size='basic'
+                      />
+                    </Dropdown>
+                  </div>
+                )}
 
                 {ORGANIZATION_LIST.map(
                   (organization) =>

--- a/src/components/feature/AutoPlan/index.tsx
+++ b/src/components/feature/AutoPlan/index.tsx
@@ -35,7 +35,7 @@ import {
 } from '@/components/common/Typography';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
 import { MealHeaderFormData } from '@/components/shared/Meal/MealHeader';
-import { ORGANIZATION_LIST } from '@/constants/_category';
+import { ORGANIZATION_LIST, SCHOOL_LEVEL_LIST } from '@/constants/_category';
 import { AUTO_PLAN_BETA_MESSAGE, MAJOR_CATEGORIES } from '@/constants/_meal';
 import {
   MEAL_FORM_LEGEND,
@@ -46,7 +46,7 @@ import { PAGE_TITLE } from '@/constants/_pageTitle';
 import { MEAL_HEADER_ERROR } from '@/constants/_schema';
 import { usePostMonthMenusAuto } from '@/hooks/menu/usePostMonthMenusAuto';
 import { usePostMonthMenusSave } from '@/hooks/menu/usePostMonthMenusSave';
-import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
+// import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
 import { useGetSearchSchool } from '@/hooks/menuCategory/useGetSearchSchool';
 import { usePrefetchMinorCategories } from '@/hooks/menuCategory/usePrefetchMinorCategories';
 import useNavigate from '@/hooks/useNavigate';
@@ -71,9 +71,10 @@ const AutoPlan = () => {
   const { navigate } = useNavigate();
 
   const queryClient = useQueryClient();
-  const { minorCategories } = useFetchMinorCategories(
-    selectedCategory.majorCategory,
-  );
+  // 현재는 대분류 '학교' 선택 시 소분류 옵션에 '초/중/고'만 보여주므로 주석처리
+  // const { minorCategories } = useFetchMinorCategories(
+  //   selectedCategory.majorCategory,
+  // );
   const { mutate: postAutoMutate } = usePostMonthMenusAuto();
   const { mutate: postSaveMutate } = usePostMonthMenusSave();
   const { prefetchMinorCategories, hasCategories } =
@@ -314,7 +315,7 @@ const AutoPlan = () => {
                     selectedCategory.majorCategory !== MAJOR_CATEGORIES[1] && (
                       <Selectbox
                         key={organization.value}
-                        options={minorCategories}
+                        options={SCHOOL_LEVEL_LIST}
                         buttonSize='sm'
                         className='min-w-[194px] justify-start'
                         onChange={(minorCategory) =>

--- a/src/components/feature/MealPlanEdit/index.tsx
+++ b/src/components/feature/MealPlanEdit/index.tsx
@@ -321,8 +321,8 @@ const MealPlanEdit = ({ id: monthMenuId }: MealPlanEditProps) => {
               selectedValue={selectedCategory.majorCategory}
               isError={isCategoryError}
             />
-            <div className='relative'>
-              {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+            {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+              <div className='relative'>
                 <div className='flex gap-4'>
                   <Input
                     variant='white'
@@ -341,15 +341,15 @@ const MealPlanEdit = ({ id: monthMenuId }: MealPlanEditProps) => {
                     <Subtitle2White>검색</Subtitle2White>
                   </Button>
                 </div>
-              )}
-              <Dropdown isOpen={isOpen} className='top-12'>
-                <OptionList
-                  options={options}
-                  onSelect={handleSchoolNameSelect}
-                  size='basic'
-                />
-              </Dropdown>
-            </div>
+                <Dropdown isOpen={isOpen} className='top-12'>
+                  <OptionList
+                    options={options}
+                    onSelect={handleSchoolNameSelect}
+                    size='basic'
+                  />
+                </Dropdown>
+              </div>
+            )}
             {ORGANIZATION_LIST.map(
               (organization) =>
                 selectedCategory.majorCategory === organization.value &&

--- a/src/components/feature/MealPlanEdit/index.tsx
+++ b/src/components/feature/MealPlanEdit/index.tsx
@@ -35,7 +35,7 @@ import {
 } from '@/components/common/Typography';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
 import { MealHeaderFormData } from '@/components/shared/Meal/MealHeader';
-import { ORGANIZATION_LIST } from '@/constants/_category';
+import { ORGANIZATION_LIST, SCHOOL_LEVEL_LIST } from '@/constants/_category';
 import { MAJOR_CATEGORIES } from '@/constants/_meal';
 import {
   MEAL_FORM_LEGEND,
@@ -45,7 +45,7 @@ import { ROUTES } from '@/constants/_navbar';
 import { PAGE_TITLE } from '@/constants/_pageTitle';
 import { MEAL_HEADER_ERROR } from '@/constants/_schema';
 import { usePutMonthMenus } from '@/hooks/menu/usePutMonthMenus';
-import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
+// import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
 import { useGetSearchSchool } from '@/hooks/menuCategory/useGetSearchSchool';
 import useNavigate from '@/hooks/useNavigate';
 import { useToastStore } from '@/stores/useToastStore';
@@ -77,9 +77,9 @@ const MealPlanEdit = ({ id: monthMenuId }: MealPlanEditProps) => {
   const { navigate, handleBack } = useNavigate();
 
   const queryClient = useQueryClient();
-  const { minorCategories } = useFetchMinorCategories(
-    selectedCategory.majorCategory,
-  );
+  // const { minorCategories } = useFetchMinorCategories(
+  //   selectedCategory.majorCategory,
+  // );
   const { mutate: putMutate } = usePutMonthMenus();
 
   const {
@@ -356,7 +356,7 @@ const MealPlanEdit = ({ id: monthMenuId }: MealPlanEditProps) => {
                 selectedCategory.majorCategory !== MAJOR_CATEGORIES[1] && (
                   <Selectbox
                     key={organization.value}
-                    options={minorCategories}
+                    options={SCHOOL_LEVEL_LIST}
                     buttonSize='sm'
                     className='min-w-[194px] justify-start'
                     onChange={(minorCategory) =>

--- a/src/components/feature/MenualPlan/index.tsx
+++ b/src/components/feature/MenualPlan/index.tsx
@@ -42,6 +42,9 @@ import useNavigate from '@/hooks/useNavigate';
 import { useMenualPlanStore } from '@/stores/useMenualPlanStore';
 import { useToastStore } from '@/stores/useToastStore';
 
+/**
+ * @description 수동 식단 작성 페이지
+ */
 const MenualPlan = () => {
   const [calendarData, setCalendarData] = useState<CalendarInfo>({});
   const [selectedDate, setSelectedDate] = useState<string>('');
@@ -240,8 +243,8 @@ const MenualPlan = () => {
                 isError={isCategoryError}
               />
 
-              <div className='relative'>
-                {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+              {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+                <div className='relative'>
                   <div className='flex gap-4'>
                     <Input
                       variant='white'
@@ -260,15 +263,15 @@ const MenualPlan = () => {
                       <Subtitle2White>검색</Subtitle2White>
                     </Button>
                   </div>
-                )}
-                <Dropdown isOpen={isOpen} className='top-12'>
-                  <OptionList
-                    options={options}
-                    onSelect={handleSchoolNameSelect}
-                    size='basic'
-                  />
-                </Dropdown>
-              </div>
+                  <Dropdown isOpen={isOpen} className='top-12'>
+                    <OptionList
+                      options={options}
+                      onSelect={handleSchoolNameSelect}
+                      size='basic'
+                    />
+                  </Dropdown>
+                </div>
+              )}
 
               {ORGANIZATION_LIST.map(
                 (item) =>

--- a/src/components/feature/MenualPlan/index.tsx
+++ b/src/components/feature/MenualPlan/index.tsx
@@ -25,7 +25,7 @@ import { Option, Selectbox } from '@/components/common/Selectbox';
 import { H2BlackH2, Subtitle2White } from '@/components/common/Typography';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
 import { MealHeaderFormData } from '@/components/shared/Meal/MealHeader';
-import { ORGANIZATION_LIST } from '@/constants/_category';
+import { ORGANIZATION_LIST, SCHOOL_LEVEL_LIST } from '@/constants/_category';
 import { MAJOR_CATEGORIES } from '@/constants/_meal';
 import {
   MEAL_FORM_LEGEND,
@@ -35,7 +35,7 @@ import { ROUTES } from '@/constants/_navbar';
 import { PAGE_TITLE } from '@/constants/_pageTitle';
 import { MEAL_HEADER_ERROR } from '@/constants/_schema';
 import { MEAL_CREATE_MESSAGE } from '@/constants/_toastMessage';
-import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
+// import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
 import { useGetSearchSchool } from '@/hooks/menuCategory/useGetSearchSchool';
 import { usePrefetchMinorCategories } from '@/hooks/menuCategory/usePrefetchMinorCategories';
 import useNavigate from '@/hooks/useNavigate';
@@ -64,9 +64,9 @@ const MenualPlan = () => {
     }),
   );
 
-  const { minorCategories } = useFetchMinorCategories(
-    selectedCategory.majorCategory,
-  );
+  // const { minorCategories } = useFetchMinorCategories(
+  //   selectedCategory.majorCategory,
+  // );
   const { prefetchMinorCategories, hasCategories } =
     usePrefetchMinorCategories();
 
@@ -276,7 +276,7 @@ const MenualPlan = () => {
                   selectedCategory.majorCategory !== MAJOR_CATEGORIES[1] && (
                     <Selectbox
                       key={item.value}
-                      options={minorCategories}
+                      options={SCHOOL_LEVEL_LIST}
                       buttonSize='sm'
                       className='min-w-[194px] justify-start'
                       onChange={(minorCategory) =>

--- a/src/components/feature/MenualPlanEdit/index.tsx
+++ b/src/components/feature/MenualPlanEdit/index.tsx
@@ -44,6 +44,9 @@ import useNavigate from '@/hooks/useNavigate';
 import { useMenualPlanStore } from '@/stores/useMenualPlanStore';
 import { useToastStore } from '@/stores/useToastStore';
 
+/**
+ * @description 수동 식단 수정 페이지
+ */
 const MenualPlanEdit = () => {
   const { monthMenuName, category, calendar } = useMenualPlanStore((state) => ({
     monthMenuName: state.monthMenuName,
@@ -250,8 +253,8 @@ const MenualPlanEdit = () => {
               selectedValue={selectedCategory.majorCategory}
               isError={isCategoryError}
             />
-            <div className='relative'>
-              {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+            {selectedCategory.majorCategory === MAJOR_CATEGORIES[1] && (
+              <div className='relative'>
                 <div className='flex gap-4'>
                   <Input
                     variant='white'
@@ -270,15 +273,15 @@ const MenualPlanEdit = () => {
                     <Subtitle2White>검색</Subtitle2White>
                   </Button>
                 </div>
-              )}
-              <Dropdown isOpen={isOpen} className='top-12'>
-                <OptionList
-                  options={options}
-                  onSelect={handleSchoolNameSelect}
-                  size='basic'
-                />
-              </Dropdown>
-            </div>
+                <Dropdown isOpen={isOpen} className='top-12'>
+                  <OptionList
+                    options={options}
+                    onSelect={handleSchoolNameSelect}
+                    size='basic'
+                  />
+                </Dropdown>
+              </div>
+            )}
 
             {ORGANIZATION_LIST.map(
               (organization) =>

--- a/src/components/feature/MenualPlanEdit/index.tsx
+++ b/src/components/feature/MenualPlanEdit/index.tsx
@@ -28,7 +28,7 @@ import { Option, Selectbox } from '@/components/common/Selectbox';
 import { H2BlackH2, Subtitle2White } from '@/components/common/Typography';
 import MealCalendar from '@/components/shared/Meal/MealCalender';
 import { MealHeaderFormData } from '@/components/shared/Meal/MealHeader';
-import { ORGANIZATION_LIST } from '@/constants/_category';
+import { ORGANIZATION_LIST, SCHOOL_LEVEL_LIST } from '@/constants/_category';
 import { MAJOR_CATEGORIES } from '@/constants/_meal';
 import {
   MEAL_FORM_LEGEND,
@@ -38,7 +38,7 @@ import { ROUTES } from '@/constants/_navbar';
 import { PAGE_TITLE } from '@/constants/_pageTitle';
 import { MEAL_HEADER_ERROR } from '@/constants/_schema';
 import { usePostMonthMenusSave } from '@/hooks/menu/usePostMonthMenusSave';
-import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
+// import { useFetchMinorCategories } from '@/hooks/menuCategory/useFetchMinorCategories';
 import { useGetSearchSchool } from '@/hooks/menuCategory/useGetSearchSchool';
 import useNavigate from '@/hooks/useNavigate';
 import { useMenualPlanStore } from '@/stores/useMenualPlanStore';
@@ -65,9 +65,9 @@ const MenualPlanEdit = () => {
   const isBothSelected =
     selectedCategory.majorCategory && selectedCategory.minorCategory;
 
-  const { minorCategories } = useFetchMinorCategories(
-    selectedCategory.majorCategory,
-  );
+  // const { minorCategories } = useFetchMinorCategories(
+  //   selectedCategory.majorCategory,
+  // );
   const { mutate: postSaveMutate } = usePostMonthMenusSave();
 
   const {
@@ -286,7 +286,7 @@ const MenualPlanEdit = () => {
                 selectedCategory.majorCategory !== MAJOR_CATEGORIES[1] && (
                   <Selectbox
                     key={organization.value}
-                    options={minorCategories}
+                    options={SCHOOL_LEVEL_LIST}
                     buttonSize='sm'
                     className='min-w-[194px] justify-start'
                     onChange={(minorCategory) =>

--- a/src/constants/_category.ts
+++ b/src/constants/_category.ts
@@ -12,19 +12,6 @@ export const ORGANIZATION_LIST = [
   { value: MAJOR_CATEGORIES[2], label: MAJOR_CATEGORIES[2] },
 ];
 
-export const MOCK_CATEGORY_LIST = [
-  SCHOOL_LEVEL_LIST,
-  ORGANIZATION_LIST,
-  [
-    { value: '1', label: '세번쨰' },
-    { value: '2', label: MAJOR_CATEGORIES[1] },
-    { value: '3', label: MAJOR_CATEGORIES[2] },
-    { value: '4', label: '세번쨰' },
-    { value: '5', label: MAJOR_CATEGORIES[1] },
-    { value: '6', label: MAJOR_CATEGORIES[2] },
-  ],
-];
-
 export const CATEGORY_MAPPINGS = [
   { category: MAJOR_CATEGORIES[0], queryKey: 'getSchoolMinorCategories' },
   // { category: MAJOR_CATEGORIES[1], queryKey: 'getSchoolNameMinorCategories' },


### PR DESCRIPTION
<!--
제목은 `Feat[#issue 번호]: 기능 구현 내용`으로 작성해 주세요
예시) Feat[#THKV-108]: 버튼 컴포넌트 기능 구현
-->

## 유형

- [ ] 기능 구현
- [ ] UI 구현
- [ ] 리팩토링
- [x] 버그 해결
- [ ] 문서 업데이트
- [ ] 기타( )

## 작업 내용

<!-- 작업한 내용을 카테고리와 함께 설명해주세요
ex) - [UI 구현] 간결하게 작성
-->

1. 소분류 카테고리 api 목록 조회 하던 부분 상수 변수로 수정하였습니다.
2. 식단 페이지 header selectbox와 버튼 간의 gap 수정하였습니다.

## 스크린샷

<!-- Responsive viewer 사용하여 PC, Tablet, Mobile 사이즈를 한 장으로 캡쳐해주세요 -->
<img width="736" alt="image" src="https://github.com/user-attachments/assets/ee9e8d32-cbab-4ea5-b0e0-729dbf94aeca" />

<img width="569" alt="image" src="https://github.com/user-attachments/assets/ec867578-8bf6-4da7-8455-df117b90b62e" />


## 리뷰 요구사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-->
- 수정사항 여러 개 한 번에 올리려고했는데, 백에서 봐줘야할 부분이 있어서 이것 먼저 올립니다~